### PR TITLE
Remove vice-president candidate names

### DIFF
--- a/2016/20161108__vt__general__precinct.csv
+++ b/2016/20161108__vt__general__precinct.csv
@@ -10427,556 +10427,556 @@ Washington,Lieutenant Governor,,Woodbury,,Total Votes Cast,,537,82052
 Bennington,Lieutenant Governor,,Woodford,,Total Votes Cast,,183,82052
 Windsor,Lieutenant Governor,,Woodstock,,Total Votes Cast,,1912,82052
 Washington,Lieutenant Governor,,Worcester,,Total Votes Cast,,600,82052
-Addison,President,,Addison,,Hillary Clinton. Tim Kaine,Democratic,324,82048
-Orleans,President,,Albany,,Hillary Clinton. Tim Kaine,Democratic,207,82048
-Grand Isle,President,,Alburgh,,Hillary Clinton. Tim Kaine,Democratic,372,82048
-Windsor,President,,Andover,,Hillary Clinton. Tim Kaine,Democratic,166,82048
-Bennington,President,,Arlington,,Hillary Clinton. Tim Kaine,Democratic,662,82048
-Windham,President,,Athens,,Hillary Clinton. Tim Kaine,Democratic,69,82048
-Franklin,President,,Bakersfield,,Hillary Clinton. Tim Kaine,Democratic,295,82048
-Windsor,President,,Baltimore,,Hillary Clinton. Tim Kaine,Democratic,50,82048
-Windsor,President,,Barnard,,Hillary Clinton. Tim Kaine,Democratic,339,82048
-Caledonia,President,,Barnet,,Hillary Clinton. Tim Kaine,Democratic,485,82048
-Washington,President,,Barre City,,Hillary Clinton. Tim Kaine,Democratic,1653,82048
-Washington,President,,Barre Town,,Hillary Clinton. Tim Kaine,Democratic,1760,82048
-Orleans,President,,Barton,,Hillary Clinton. Tim Kaine,Democratic,502,82048
-Lamoille,President,,Belvidere,,Hillary Clinton. Tim Kaine,Democratic,53,82048
-Bennington,President,,Bennington,Bennington 2-1,Hillary Clinton. Tim Kaine,Democratic,1764,82048
-Bennington,President,,Bennington,Bennington 2-2,Hillary Clinton. Tim Kaine,Democratic,1597,82048
-Rutland,President,,Benson,,Hillary Clinton. Tim Kaine,Democratic,216,82048
-Franklin,President,,Berkshire,,Hillary Clinton. Tim Kaine,Democratic,209,82048
-Washington,President,,Berlin,,Hillary Clinton. Tim Kaine,Democratic,658,82048
-Windsor,President,,Bethel,,Hillary Clinton. Tim Kaine,Democratic,543,82048
-Essex,President,,Bloomfield,,Hillary Clinton. Tim Kaine,Democratic,30,82048
-Chittenden,President,,Bolton,,Hillary Clinton. Tim Kaine,Democratic,389,82048
-Orange,President,,Bradford,,Hillary Clinton. Tim Kaine,Democratic,624,82048
-Orange,President,,Braintree,,Hillary Clinton. Tim Kaine,Democratic,289,82048
-Rutland,President,,Brandon,,Hillary Clinton. Tim Kaine,Democratic,924,82048
-Windham,President,,Brattleboro,Windham 2-1,Hillary Clinton. Tim Kaine,Democratic,1489,82048
-Windham,President,,Brattleboro,Windham 2-2,Hillary Clinton. Tim Kaine,Democratic,1367,82048
-Windham,President,,Brattleboro,Windham 2-3,Hillary Clinton. Tim Kaine,Democratic,1491,82048
-Windsor,President,,Bridgewater,,Hillary Clinton. Tim Kaine,Democratic,280,82048
-Addison,President,,Bridport,,Hillary Clinton. Tim Kaine,Democratic,292,82048
-Essex,President,,Brighton,,Hillary Clinton. Tim Kaine,Democratic,229,82048
-Addison,President,,Bristol,,Hillary Clinton. Tim Kaine,Democratic,1075,82048
-Orange,President,,Brookfield,,Hillary Clinton. Tim Kaine,Democratic,378,82048
-Windham,President,,Brookline,,Hillary Clinton. Tim Kaine,Democratic,169,82048
-Orleans,President,,Brownington,,Hillary Clinton. Tim Kaine,Democratic,146,82048
-Essex,President,,Brunswick,,Hillary Clinton. Tim Kaine,Democratic,21,82048
-Caledonia,President,,Burke,,Hillary Clinton. Tim Kaine,Democratic,381,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Hillary Clinton. Tim Kaine,Democratic,3023,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Hillary Clinton. Tim Kaine,Democratic,1697,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Hillary Clinton. Tim Kaine,Democratic,2818,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Hillary Clinton. Tim Kaine,Democratic,2028,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Hillary Clinton. Tim Kaine,Democratic,3922,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Hillary Clinton. Tim Kaine,Democratic,933,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Hillary Clinton. Tim Kaine,Democratic,98,82048
-Washington,President,,Cabot,,Hillary Clinton. Tim Kaine,Democratic,394,82048
-Washington,President,,Calais,,Hillary Clinton. Tim Kaine,Democratic,688,82048
-Lamoille,President,,Cambridge,,Hillary Clinton. Tim Kaine,Democratic,1067,82048
-Essex,President,,Canaan,,Hillary Clinton. Tim Kaine,Democratic,179,82048
-Rutland,President,,Castleton,,Hillary Clinton. Tim Kaine,Democratic,795,82048
-Windsor,President,,Cavendish,,Hillary Clinton. Tim Kaine,Democratic,306,82048
-Orleans,President,,Charleston,,Hillary Clinton. Tim Kaine,Democratic,184,82048
-Chittenden,President,,Charlotte,,Hillary Clinton. Tim Kaine,Democratic,1794,82048
-Orange,President,,Chelsea,,Hillary Clinton. Tim Kaine,Democratic,304,82048
-Windsor,President,,Chester,,Hillary Clinton. Tim Kaine,Democratic,827,82048
-Rutland,President,,Chittenden,,Hillary Clinton. Tim Kaine,Democratic,352,82048
-Rutland,President,,Clarendon,,Hillary Clinton. Tim Kaine,Democratic,470,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Hillary Clinton. Tim Kaine,Democratic,1929,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Hillary Clinton. Tim Kaine,Democratic,2554,82048
-Essex,President,,Concord,,Hillary Clinton. Tim Kaine,Democratic,181,82048
-Orange,President,,Corinth,,Hillary Clinton. Tim Kaine,Democratic,308,82048
-Addison,President,,Cornwall,,Hillary Clinton. Tim Kaine,Democratic,517,82048
-Orleans,President,,Coventry,,Hillary Clinton. Tim Kaine,Democratic,196,82048
-Orleans,President,,Craftsbury,,Hillary Clinton. Tim Kaine,Democratic,435,82048
-Rutland,President,,Danby,,Hillary Clinton. Tim Kaine,Democratic,252,82048
-Caledonia,President,,Danville,,Hillary Clinton. Tim Kaine,Democratic,645,82048
-Orleans,President,,Derby,,Hillary Clinton. Tim Kaine,Democratic,885,82048
-Bennington,President,,Dorset,,Hillary Clinton. Tim Kaine,Democratic,740,82048
-Windham,President,,Dover,,Hillary Clinton. Tim Kaine,Democratic,409,82048
-Windham,President,,Dummerston,,Hillary Clinton. Tim Kaine,Democratic,797,82048
-Washington,President,,Duxbury,,Hillary Clinton. Tim Kaine,Democratic,434,82048
-Essex,President,,East Haven,,Hillary Clinton. Tim Kaine,Democratic,51,82048
-Washington,President,,East Montpelier,,Hillary Clinton. Tim Kaine,Democratic,1032,82048
-Lamoille,President,,Eden,,Hillary Clinton. Tim Kaine,Democratic,221,82048
-Lamoille,President,,Elmore,,Hillary Clinton. Tim Kaine,Democratic,339,82048
-Franklin,President,,Enosburgh,,Hillary Clinton. Tim Kaine,Democratic,502,82048
-Chittenden,President,,Essex,Chittenden 8-1,Hillary Clinton. Tim Kaine,Democratic,2847,82048
-Chittenden,President,,Essex,Chittenden 8-2,Hillary Clinton. Tim Kaine,Democratic,3057,82048
-Chittenden,President,,Essex,Chittenden 8-3,Hillary Clinton. Tim Kaine,Democratic,849,82048
-Rutland,President,,Fair Haven,,Hillary Clinton. Tim Kaine,Democratic,478,82048
-Franklin,President,,Fairfax,,Hillary Clinton. Tim Kaine,Democratic,1063,82048
-Franklin,President,,Fairfield,,Hillary Clinton. Tim Kaine,Democratic,489,82048
-Orange,President,,Fairlee,,Hillary Clinton. Tim Kaine,Democratic,350,82048
-Washington,President,,Fayston,,Hillary Clinton. Tim Kaine,Democratic,586,82048
-Addison,President,,Ferrisburgh,,Hillary Clinton. Tim Kaine,Democratic,892,82048
-Franklin,President,,Fletcher,,Hillary Clinton. Tim Kaine,Democratic,336,82048
-Franklin,President,,Franklin,,Hillary Clinton. Tim Kaine,Democratic,229,82048
-Franklin,President,,Georgia,,Hillary Clinton. Tim Kaine,Democratic,1019,82048
-Orleans,President,,Glover,,Hillary Clinton. Tim Kaine,Democratic,290,82048
-Addison,President,,Goshen,,Hillary Clinton. Tim Kaine,Democratic,78,82048
-Windham,President,,Grafton,,Hillary Clinton. Tim Kaine,Democratic,210,82048
-Essex,President,,Granby,,Hillary Clinton. Tim Kaine,Democratic,12,82048
-Grand Isle,President,,Grand Isle,,Hillary Clinton. Tim Kaine,Democratic,594,82048
-Addison,President,,Granville,,Hillary Clinton. Tim Kaine,Democratic,82,82048
-Orleans,President,,Greensboro,,Hillary Clinton. Tim Kaine,Democratic,271,82048
-Caledonia,President,,Groton,,Hillary Clinton. Tim Kaine,Democratic,159,82048
-Essex,President,,Guildhall,,Hillary Clinton. Tim Kaine,Democratic,40,82048
-Windham,President,,Guilford,,Hillary Clinton. Tim Kaine,Democratic,719,82048
-Windham,President,,Halifax,,Hillary Clinton. Tim Kaine,Democratic,202,82048
-Addison,President,,Hancock,,Hillary Clinton. Tim Kaine,Democratic,75,82048
-Caledonia,President,,Hardwick,,Hillary Clinton. Tim Kaine,Democratic,651,82048
-Windsor,President,,Hartford,Windsor 4-1,Hillary Clinton. Tim Kaine,Democratic,738,82048
-Windsor,President,,Hartford,Windsor 4-2,Hillary Clinton. Tim Kaine,Democratic,2452,82048
-Windsor,President,,Hartland,,Hillary Clinton. Tim Kaine,Democratic,1158,82048
-Franklin,President,,Highgate,,Hillary Clinton. Tim Kaine,Democratic,474,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Hillary Clinton. Tim Kaine,Democratic,15,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Hillary Clinton. Tim Kaine,Democratic,1711,82048
-Orleans,President,,Holland,,Hillary Clinton. Tim Kaine,Democratic,81,82048
-Rutland,President,,Hubbardton,,Hillary Clinton. Tim Kaine,Democratic,188,82048
-Chittenden,President,,Huntington,,Hillary Clinton. Tim Kaine,Democratic,796,82048
-Lamoille,President,,Hyde Park,,Hillary Clinton. Tim Kaine,Democratic,788,82048
-Rutland,President,,Ira,,Hillary Clinton. Tim Kaine,Democratic,102,82048
-Orleans,President,,Irasburg,,Hillary Clinton. Tim Kaine,Democratic,194,82048
-Grand Isle,President,,Isle La Motte,,Hillary Clinton. Tim Kaine,Democratic,136,82048
-Windham,President,,Jamaica,,Hillary Clinton. Tim Kaine,Democratic,311,82048
-Orleans,President,,Jay,,Hillary Clinton. Tim Kaine,Democratic,113,82048
-Chittenden,President,,Jericho,,Hillary Clinton. Tim Kaine,Democratic,2017,82048
-Lamoille,President,,Johnson,,Hillary Clinton. Tim Kaine,Democratic,691,82048
-Rutland,President,,Killington,,Hillary Clinton. Tim Kaine,Democratic,357,82048
-Caledonia,President,,Kirby,,Hillary Clinton. Tim Kaine,Democratic,125,82048
-Bennington,President,,Landgrove,,Hillary Clinton. Tim Kaine,Democratic,71,82048
-Addison,President,,Leicester,,Hillary Clinton. Tim Kaine,Democratic,217,82048
-Essex,President,,Lemington,,Hillary Clinton. Tim Kaine,Democratic,18,82048
-Addison,President,,Lincoln,,Hillary Clinton. Tim Kaine,Democratic,494,82048
-Windham,President,,Londonderry,,Hillary Clinton. Tim Kaine,Democratic,517,82048
-Orleans,President,,Lowell,,Hillary Clinton. Tim Kaine,Democratic,123,82048
-Windsor,President,,Ludlow,,Hillary Clinton. Tim Kaine,Democratic,538,82048
-Essex,President,,Lunenburg,,Hillary Clinton. Tim Kaine,Democratic,171,82048
-Caledonia,President,,Lyndon,,Hillary Clinton. Tim Kaine,Democratic,827,82048
-Essex,President,,Maidstone,,Hillary Clinton. Tim Kaine,Democratic,39,82048
-Bennington,President,,Manchester,,Hillary Clinton. Tim Kaine,Democratic,1452,82048
-Windham,President,,Marlboro,,Hillary Clinton. Tim Kaine,Democratic,432,82048
-Washington,President,,Marshfield,,Hillary Clinton. Tim Kaine,Democratic,417,82048
-Rutland,President,,Mendon,,Hillary Clinton. Tim Kaine,Democratic,302,82048
-Addison,President,,Middlebury,,Hillary Clinton. Tim Kaine,Democratic,2682,82048
-Washington,President,,Middlesex,,Hillary Clinton. Tim Kaine,Democratic,719,82048
-Rutland,President,,Middletown Springs,,Hillary Clinton. Tim Kaine,Democratic,233,82048
-Chittenden,President,,Milton,Chittenden 10,Hillary Clinton. Tim Kaine,Democratic,1950,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Hillary Clinton. Tim Kaine,Democratic,310,82048
-Addison,President,,Monkton,,Hillary Clinton. Tim Kaine,Democratic,671,82048
-Franklin,President,,Montgomery,,Hillary Clinton. Tim Kaine,Democratic,302,82048
-Washington,President,,Montpelier,,Hillary Clinton. Tim Kaine,Democratic,3698,82048
-Washington,President,,Moretown,,Hillary Clinton. Tim Kaine,Democratic,649,82048
-Orleans,President,,Morgan,,Hillary Clinton. Tim Kaine,Democratic,101,82048
-Lamoille,President,,Morristown,,Hillary Clinton. Tim Kaine,Democratic,1550,82048
-Rutland,President,,Mount Holly,,Hillary Clinton. Tim Kaine,Democratic,337,82048
-Rutland,President,,Mount Tabor,,Hillary Clinton. Tim Kaine,Democratic,45,82048
-Addison,President,,New Haven,,Hillary Clinton. Tim Kaine,Democratic,594,82048
-Caledonia,President,,Newark,,Hillary Clinton. Tim Kaine,Democratic,130,82048
-Orange,President,,Newbury,,Hillary Clinton. Tim Kaine,Democratic,528,82048
-Windham,President,,Newfane,,Hillary Clinton. Tim Kaine,Democratic,652,82048
-Orleans,President,,Newport City,,Hillary Clinton. Tim Kaine,Democratic,721,82048
-Orleans,President,,Newport Town,,Hillary Clinton. Tim Kaine,Democratic,256,82048
-Grand Isle,President,,North Hero,,Hillary Clinton. Tim Kaine,Democratic,320,82048
-Washington,President,,Northfield,,Hillary Clinton. Tim Kaine,Democratic,1113,82048
-Essex,President,,Norton,,Hillary Clinton. Tim Kaine,Democratic,30,82048
-Windsor,President,,Norwich,,Hillary Clinton. Tim Kaine,Democratic,1982,82048
-Orange,President,,Orange,,Hillary Clinton. Tim Kaine,Democratic,186,82048
-Addison,President,,Orwell,,Hillary Clinton. Tim Kaine,Democratic,270,82048
-Addison,President,,Panton,,Hillary Clinton. Tim Kaine,Democratic,171,82048
-Rutland,President,,Pawlet,,Hillary Clinton. Tim Kaine,Democratic,368,82048
-Caledonia,President,,Peacham,,Hillary Clinton. Tim Kaine,Democratic,291,82048
-Bennington,President,,Peru,,Hillary Clinton. Tim Kaine,Democratic,166,82048
-Rutland,President,,Pittsfield,,Hillary Clinton. Tim Kaine,Democratic,147,82048
-Rutland,President,,Pittsford,,Hillary Clinton. Tim Kaine,Democratic,668,82048
-Washington,President,,Plainfield,,Hillary Clinton. Tim Kaine,Democratic,424,82048
-Windsor,President,,Plymouth,,Hillary Clinton. Tim Kaine,Democratic,173,82048
-Windsor,President,,Pomfret,,Hillary Clinton. Tim Kaine,Democratic,395,82048
-Rutland,President,,Poultney,,Hillary Clinton. Tim Kaine,Democratic,652,82048
-Bennington,President,,Pownal,,Hillary Clinton. Tim Kaine,Democratic,761,82048
-Rutland,President,,Proctor,,Hillary Clinton. Tim Kaine,Democratic,385,82048
-Windham,President,,Putney,,Hillary Clinton. Tim Kaine,Democratic,992,82048
-Orange,President,,Randolph,,Hillary Clinton. Tim Kaine,Democratic,1160,82048
-Windsor,President,,Reading,,Hillary Clinton. Tim Kaine,Democratic,231,82048
-Bennington,President,,Readsboro,,Hillary Clinton. Tim Kaine,Democratic,166,82048
-Franklin,President,,Richford,,Hillary Clinton. Tim Kaine,Democratic,324,82048
-Chittenden,President,,Richmond,,Hillary Clinton. Tim Kaine,Democratic,1694,82048
-Addison,President,,Ripton,,Hillary Clinton. Tim Kaine,Democratic,228,82048
-Windsor,President,,Rochester,,Hillary Clinton. Tim Kaine,Democratic,393,82048
-Windham,President,,Rockingham,,Hillary Clinton. Tim Kaine,Democratic,1315,82048
-Washington,President,,Roxbury,,Hillary Clinton. Tim Kaine,Democratic,186,82048
-Windsor,President,,Royalton,,Hillary Clinton. Tim Kaine,Democratic,698,82048
-Bennington,President,,Rupert,,Hillary Clinton. Tim Kaine,Democratic,213,82048
-Rutland,President,,Rutland City,Rutland 5-1,Hillary Clinton. Tim Kaine,Democratic,1162,82048
-Rutland,President,,Rutland City,Rutland 5-2,Hillary Clinton. Tim Kaine,Democratic,911,82048
-Rutland,President,,Rutland City,Rutland 5-3,Hillary Clinton. Tim Kaine,Democratic,587,82048
-Rutland,President,,Rutland City,Rutland 5-4,Hillary Clinton. Tim Kaine,Democratic,835,82048
-Rutland,President,,Rutland Town,,Hillary Clinton. Tim Kaine,Democratic,1064,82048
-Caledonia,President,,Ryegate,,Hillary Clinton. Tim Kaine,Democratic,252,82048
-Addison,President,,Salisbury,,Hillary Clinton. Tim Kaine,Democratic,296,82048
-Bennington,President,,Sandgate,,Hillary Clinton. Tim Kaine,Democratic,99,82048
-Bennington,President,,Searsburg,,Hillary Clinton. Tim Kaine,Democratic,19,82048
-Bennington,President,,Shaftsbury,,Hillary Clinton. Tim Kaine,Democratic,952,82048
-Windsor,President,,Sharon,,Hillary Clinton. Tim Kaine,Democratic,428,82048
-Caledonia,President,,Sheffield,,Hillary Clinton. Tim Kaine,Democratic,110,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Hillary Clinton. Tim Kaine,Democratic,1930,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Hillary Clinton. Tim Kaine,Democratic,1460,82048
-Franklin,President,,Sheldon,,Hillary Clinton. Tim Kaine,Democratic,305,82048
-Addison,President,,Shoreham,,Hillary Clinton. Tim Kaine,Democratic,356,82048
-Rutland,President,,Shrewsbury,,Hillary Clinton. Tim Kaine,Democratic,325,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Hillary Clinton. Tim Kaine,Democratic,1899,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Hillary Clinton. Tim Kaine,Democratic,2064,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Hillary Clinton. Tim Kaine,Democratic,1810,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Hillary Clinton. Tim Kaine,Democratic,1473,82048
-Grand Isle,President,,South Hero,,Hillary Clinton. Tim Kaine,Democratic,672,82048
-Windsor,President,,Springfield,Windsor 3-1,Hillary Clinton. Tim Kaine,Democratic,71,82048
-Windsor,President,,Springfield,Windsor 3-2,Hillary Clinton. Tim Kaine,Democratic,1802,82048
-Franklin,President,,Saint Albans City,,Hillary Clinton. Tim Kaine,Democratic,1287,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Hillary Clinton. Tim Kaine,Democratic,465,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Hillary Clinton. Tim Kaine,Democratic,951,82048
-Chittenden,President,,Saint George,,Hillary Clinton. Tim Kaine,Democratic,200,82048
-Caledonia,President,,Saint Johnsbury,,Hillary Clinton. Tim Kaine,Democratic,1469,82048
-Bennington,President,,Stamford,,Hillary Clinton. Tim Kaine,Democratic,203,82048
-Caledonia,President,,Stannard,,Hillary Clinton. Tim Kaine,Democratic,58,82048
-Addison,President,,Starksboro,,Hillary Clinton. Tim Kaine,Democratic,534,82048
-Windsor,President,,Stockbridge,,Hillary Clinton. Tim Kaine,Democratic,222,82048
-Lamoille,President,,Stowe,,Hillary Clinton. Tim Kaine,Democratic,1974,82048
-Orange,President,,Strafford,,Hillary Clinton. Tim Kaine,Democratic,500,82048
-Windham,President,,Stratton,,Hillary Clinton. Tim Kaine,Democratic,65,82048
-Rutland,President,,Sudbury,,Hillary Clinton. Tim Kaine,Democratic,163,82048
-Bennington,President,,Sunderland,Bennington 3,Hillary Clinton. Tim Kaine,Democratic,62,82048
-Bennington,President,,Sunderland,Bennington 4,Hillary Clinton. Tim Kaine,Democratic,219,82048
-Caledonia,President,,Sutton,,Hillary Clinton. Tim Kaine,Democratic,168,82048
-Franklin,President,,Swanton,,Hillary Clinton. Tim Kaine,Democratic,1101,82048
-Orange,President,,Thetford,,Hillary Clinton. Tim Kaine,Democratic,1145,82048
-Rutland,President,,Tinmouth,Rutland 2,Hillary Clinton. Tim Kaine,Democratic,34,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Hillary Clinton. Tim Kaine,Democratic,105,82048
-Orange,President,,Topsham,,Hillary Clinton. Tim Kaine,Democratic,226,82048
-Windham,President,,Townshend,,Hillary Clinton. Tim Kaine,Democratic,412,82048
-Orleans,President,,Troy,Orleans 2,Hillary Clinton. Tim Kaine,Democratic,63,82048
-Orleans,President,,Troy,Orleans-Lamoille,Hillary Clinton. Tim Kaine,Democratic,180,82048
-Orange,President,,Tunbridge,,Hillary Clinton. Tim Kaine,Democratic,349,82048
-Chittenden,President,,Underhill,,Hillary Clinton. Tim Kaine,Democratic,1238,82048
-Addison,President,,Vergennes,,Hillary Clinton. Tim Kaine,Democratic,712,82048
-Windham,President,,Vernon,,Hillary Clinton. Tim Kaine,Democratic,492,82048
-Orange,President,,Vershire,,Hillary Clinton. Tim Kaine,Democratic,189,82048
-Essex,President,,Victory,,Hillary Clinton. Tim Kaine,Democratic,18,82048
-Washington,President,,Waitsfield,,Hillary Clinton. Tim Kaine,Democratic,751,82048
-Caledonia,President,,Walden,,Hillary Clinton. Tim Kaine,Democratic,246,82048
-Rutland,President,,Wallingford,,Hillary Clinton. Tim Kaine,Democratic,529,82048
-Addison,President,,Waltham,,Hillary Clinton. Tim Kaine,Democratic,149,82048
-Windham,President,,Wardsboro,,Hillary Clinton. Tim Kaine,Democratic,199,82048
-Washington,President,,Warren,,Hillary Clinton. Tim Kaine,Democratic,752,82048
-Orange,President,,Washington,,Hillary Clinton. Tim Kaine,Democratic,217,82048
-Washington,President,,Waterbury,,Hillary Clinton. Tim Kaine,Democratic,2035,82048
-Caledonia,President,,Waterford,,Hillary Clinton. Tim Kaine,Democratic,292,82048
-Lamoille,President,,Waterville,,Hillary Clinton. Tim Kaine,Democratic,161,82048
-Windsor,President,,Weathersfield,,Hillary Clinton. Tim Kaine,Democratic,745,82048
-Rutland,President,,Wells,,Hillary Clinton. Tim Kaine,Democratic,209,82048
-Orange,President,,West Fairlee,,Hillary Clinton. Tim Kaine,Democratic,161,82048
-Rutland,President,,West Haven,,Hillary Clinton. Tim Kaine,Democratic,56,82048
-Rutland,President,,West Rutland,,Hillary Clinton. Tim Kaine,Democratic,384,82048
-Windsor,President,,West Windsor,,Hillary Clinton. Tim Kaine,Democratic,469,82048
-Orleans,President,,Westfield,,Hillary Clinton. Tim Kaine,Democratic,134,82048
-Chittenden,President,,Westford,,Hillary Clinton. Tim Kaine,Democratic,696,82048
-Windham,President,,Westminster,Windham 3,Hillary Clinton. Tim Kaine,Democratic,41,82048
-Windham,President,,Westminster,Windham 4,Hillary Clinton. Tim Kaine,Democratic,960,82048
-Orleans,President,,Westmore,,Hillary Clinton. Tim Kaine,Democratic,103,82048
-Windsor,President,,Weston,,Hillary Clinton. Tim Kaine,Democratic,267,82048
-Addison,President,,Weybridge,,Hillary Clinton. Tim Kaine,Democratic,415,82048
-Caledonia,President,,Wheelock,,Hillary Clinton. Tim Kaine,Democratic,156,82048
-Addison,President,,Whiting,,Hillary Clinton. Tim Kaine,Democratic,95,82048
-Windham,President,,Whitingham,Windham 6,Hillary Clinton. Tim Kaine,Democratic,268,82048
-Windham,President,,Whitingham,Windham-Bennington,Hillary Clinton. Tim Kaine,Democratic,15,82048
-Orange,President,,Williamstown,,Hillary Clinton. Tim Kaine,Democratic,627,82048
-Chittenden,President,,Williston,,Hillary Clinton. Tim Kaine,Democratic,3508,82048
-Windham,President,,Wilmington,,Hillary Clinton. Tim Kaine,Democratic,591,82048
-Windham,President,,Windham,,Hillary Clinton. Tim Kaine,Democratic,156,82048
-Windsor,President,,Windsor,,Hillary Clinton. Tim Kaine,Democratic,964,82048
-Bennington,President,,Winhall,,Hillary Clinton. Tim Kaine,Democratic,299,82048
-Chittenden,President,,Winooski,,Hillary Clinton. Tim Kaine,Democratic,2105,82048
-Lamoille,President,,Wolcott,,Hillary Clinton. Tim Kaine,Democratic,397,82048
-Washington,President,,Woodbury,,Hillary Clinton. Tim Kaine,Democratic,271,82048
-Bennington,President,,Woodford,,Hillary Clinton. Tim Kaine,Democratic,94,82048
-Windsor,President,,Woodstock,,Hillary Clinton. Tim Kaine,Democratic,1319,82048
-Washington,President,,Worcester,,Hillary Clinton. Tim Kaine,Democratic,374,82048
-Addison,President,,Addison,,Donald Trump. Michael R,Republican,337,82048
-Orleans,President,,Albany,,Donald Trump. Michael R,Republican,183,82048
-Grand Isle,President,,Alburgh,,Donald Trump. Michael R,Republican,399,82048
-Windsor,President,,Andover,,Donald Trump. Michael R,Republican,125,82048
-Bennington,President,,Arlington,,Donald Trump. Michael R,Republican,435,82048
-Windham,President,,Athens,,Donald Trump. Michael R,Republican,61,82048
-Franklin,President,,Bakersfield,,Donald Trump. Michael R,Republican,209,82048
-Windsor,President,,Baltimore,,Donald Trump. Michael R,Republican,60,82048
-Windsor,President,,Barnard,,Donald Trump. Michael R,Republican,174,82048
-Caledonia,President,,Barnet,,Donald Trump. Michael R,Republican,355,82048
-Washington,President,,Barre City,,Donald Trump. Michael R,Republican,1091,82048
-Washington,President,,Barre Town,,Donald Trump. Michael R,Republican,1862,82048
-Orleans,President,,Barton,,Donald Trump. Michael R,Republican,425,82048
-Lamoille,President,,Belvidere,,Donald Trump. Michael R,Republican,85,82048
-Bennington,President,,Bennington,Bennington 2-1,Donald Trump. Michael R,Republican,970,82048
-Bennington,President,,Bennington,Bennington 2-2,Donald Trump. Michael R,Republican,979,82048
-Rutland,President,,Benson,,Donald Trump. Michael R,Republican,232,82048
-Franklin,President,,Berkshire,,Donald Trump. Michael R,Republican,308,82048
-Washington,President,,Berlin,,Donald Trump. Michael R,Republican,454,82048
-Windsor,President,,Bethel,,Donald Trump. Michael R,Republican,299,82048
-Essex,President,,Bloomfield,,Donald Trump. Michael R,Republican,52,82048
-Chittenden,President,,Bolton,,Donald Trump. Michael R,Republican,205,82048
-Orange,President,,Bradford,,Donald Trump. Michael R,Republican,409,82048
-Orange,President,,Braintree,,Donald Trump. Michael R,Republican,217,82048
-Rutland,President,,Brandon,,Donald Trump. Michael R,Republican,723,82048
-Windham,President,,Brattleboro,Windham 2-1,Donald Trump. Michael R,Republican,426,82048
-Windham,President,,Brattleboro,Windham 2-2,Donald Trump. Michael R,Republican,216,82048
-Windham,President,,Brattleboro,Windham 2-3,Donald Trump. Michael R,Republican,217,82048
-Windsor,President,,Bridgewater,,Donald Trump. Michael R,Republican,160,82048
-Addison,President,,Bridport,,Donald Trump. Michael R,Republican,278,82048
-Essex,President,,Brighton,,Donald Trump. Michael R,Republican,276,82048
-Addison,President,,Bristol,,Donald Trump. Michael R,Republican,558,82048
-Orange,President,,Brookfield,,Donald Trump. Michael R,Republican,231,82048
-Windham,President,,Brookline,,Donald Trump. Michael R,Republican,68,82048
-Orleans,President,,Brownington,,Donald Trump. Michael R,Republican,193,82048
-Essex,President,,Brunswick,,Donald Trump. Michael R,Republican,28,82048
-Caledonia,President,,Burke,,Donald Trump. Michael R,Republican,336,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Donald Trump. Michael R,Republican,855,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Donald Trump. Michael R,Republican,278,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Donald Trump. Michael R,Republican,258,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Donald Trump. Michael R,Republican,150,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Donald Trump. Michael R,Republican,460,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Donald Trump. Michael R,Republican,74,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Donald Trump. Michael R,Republican,7,82048
-Washington,President,,Cabot,,Donald Trump. Michael R,Republican,252,82048
-Washington,President,,Calais,,Donald Trump. Michael R,Republican,195,82048
-Lamoille,President,,Cambridge,,Donald Trump. Michael R,Republican,520,82048
-Essex,President,,Canaan,,Donald Trump. Michael R,Republican,207,82048
-Rutland,President,,Castleton,,Donald Trump. Michael R,Republican,808,82048
-Windsor,President,,Cavendish,,Donald Trump. Michael R,Republican,262,82048
-Orleans,President,,Charleston,,Donald Trump. Michael R,Republican,210,82048
-Chittenden,President,,Charlotte,,Donald Trump. Michael R,Republican,512,82048
-Orange,President,,Chelsea,,Donald Trump. Michael R,Republican,273,82048
-Windsor,President,,Chester,,Donald Trump. Michael R,Republican,512,82048
-Rutland,President,,Chittenden,,Donald Trump. Michael R,Republican,312,82048
-Rutland,President,,Clarendon,,Donald Trump. Michael R,Republican,641,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Donald Trump. Michael R,Republican,988,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Donald Trump. Michael R,Republican,1437,82048
-Essex,President,,Concord,,Donald Trump. Michael R,Republican,292,82048
-Orange,President,,Corinth,,Donald Trump. Michael R,Republican,264,82048
-Addison,President,,Cornwall,,Donald Trump. Michael R,Republican,147,82048
-Orleans,President,,Coventry,,Donald Trump. Michael R,Republican,244,82048
-Orleans,President,,Craftsbury,,Donald Trump. Michael R,Republican,153,82048
-Rutland,President,,Danby,,Donald Trump. Michael R,Republican,291,82048
-Caledonia,President,,Danville,,Donald Trump. Michael R,Republican,494,82048
-Orleans,President,,Derby,,Donald Trump. Michael R,Republican,1004,82048
-Bennington,President,,Dorset,,Donald Trump. Michael R,Republican,334,82048
-Windham,President,,Dover,,Donald Trump. Michael R,Republican,279,82048
-Windham,President,,Dummerston,,Donald Trump. Michael R,Republican,213,82048
-Washington,President,,Duxbury,,Donald Trump. Michael R,Republican,196,82048
-Essex,President,,East Haven,,Donald Trump. Michael R,Republican,70,82048
-Washington,President,,East Montpelier,,Donald Trump. Michael R,Republican,356,82048
-Lamoille,President,,Eden,,Donald Trump. Michael R,Republican,241,82048
-Lamoille,President,,Elmore,,Donald Trump. Michael R,Republican,132,82048
-Franklin,President,,Enosburgh,,Donald Trump. Michael R,Republican,429,82048
-Chittenden,President,,Essex,Chittenden 8-1,Donald Trump. Michael R,Republican,1274,82048
-Chittenden,President,,Essex,Chittenden 8-2,Donald Trump. Michael R,Republican,1331,82048
-Chittenden,President,,Essex,Chittenden 8-3,Donald Trump. Michael R,Republican,425,82048
-Rutland,President,,Fair Haven,,Donald Trump. Michael R,Republican,529,82048
-Franklin,President,,Fairfax,,Donald Trump. Michael R,Republican,947,82048
-Franklin,President,,Fairfield,,Donald Trump. Michael R,Republican,338,82048
-Orange,President,,Fairlee,,Donald Trump. Michael R,Republican,149,82048
-Washington,President,,Fayston,,Donald Trump. Michael R,Republican,142,82048
-Addison,President,,Ferrisburgh,,Donald Trump. Michael R,Republican,501,82048
-Franklin,President,,Fletcher,,Donald Trump. Michael R,Republican,240,82048
-Franklin,President,,Franklin,,Donald Trump. Michael R,Republican,296,82048
-Franklin,President,,Georgia,,Donald Trump. Michael R,Republican,1023,82048
-Orleans,President,,Glover,,Donald Trump. Michael R,Republican,193,82048
-Addison,President,,Goshen,,Donald Trump. Michael R,Republican,31,82048
-Windham,President,,Grafton,,Donald Trump. Michael R,Republican,131,82048
-Essex,President,,Granby,,Donald Trump. Michael R,Republican,22,82048
-Grand Isle,President,,Grand Isle,,Donald Trump. Michael R,Republican,431,82048
-Addison,President,,Granville,,Donald Trump. Michael R,Republican,29,82048
-Orleans,President,,Greensboro,,Donald Trump. Michael R,Republican,96,82048
-Caledonia,President,,Groton,,Donald Trump. Michael R,Republican,234,82048
-Essex,President,,Guildhall,,Donald Trump. Michael R,Republican,76,82048
-Windham,President,,Guilford,,Donald Trump. Michael R,Republican,274,82048
-Windham,President,,Halifax,,Donald Trump. Michael R,Republican,183,82048
-Addison,President,,Hancock,,Donald Trump. Michael R,Republican,54,82048
-Caledonia,President,,Hardwick,,Donald Trump. Michael R,Republican,501,82048
-Windsor,President,,Hartford,Windsor 4-1,Donald Trump. Michael R,Republican,356,82048
-Windsor,President,,Hartford,Windsor 4-2,Donald Trump. Michael R,Republican,947,82048
-Windsor,President,,Hartland,,Donald Trump. Michael R,Republican,558,82048
-Franklin,President,,Highgate,,Donald Trump. Michael R,Republican,699,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Donald Trump. Michael R,Republican,4,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Donald Trump. Michael R,Republican,619,82048
-Orleans,President,,Holland,,Donald Trump. Michael R,Republican,175,82048
-Rutland,President,,Hubbardton,,Donald Trump. Michael R,Republican,163,82048
-Chittenden,President,,Huntington,,Donald Trump. Michael R,Republican,232,82048
-Lamoille,President,,Hyde Park,,Donald Trump. Michael R,Republican,475,82048
-Rutland,President,,Ira,,Donald Trump. Michael R,Republican,103,82048
-Orleans,President,,Irasburg,,Donald Trump. Michael R,Republican,284,82048
-Grand Isle,President,,Isle La Motte,,Donald Trump. Michael R,Republican,140,82048
-Windham,President,,Jamaica,,Donald Trump. Michael R,Republican,132,82048
-Orleans,President,,Jay,,Donald Trump. Michael R,Republican,101,82048
-Chittenden,President,,Jericho,,Donald Trump. Michael R,Republican,890,82048
-Lamoille,President,,Johnson,,Donald Trump. Michael R,Republican,395,82048
-Rutland,President,,Killington,,Donald Trump. Michael R,Republican,232,82048
-Caledonia,President,,Kirby,,Donald Trump. Michael R,Republican,96,82048
-Bennington,President,,Landgrove,,Donald Trump. Michael R,Republican,18,82048
-Addison,President,,Leicester,,Donald Trump. Michael R,Republican,207,82048
-Essex,President,,Lemington,,Donald Trump. Michael R,Republican,28,82048
-Addison,President,,Lincoln,,Donald Trump. Michael R,Republican,188,82048
-Windham,President,,Londonderry,,Donald Trump. Michael R,Republican,303,82048
-Orleans,President,,Lowell,,Donald Trump. Michael R,Republican,250,82048
-Windsor,President,,Ludlow,,Donald Trump. Michael R,Republican,403,82048
-Essex,President,,Lunenburg,,Donald Trump. Michael R,Republican,311,82048
-Caledonia,President,,Lyndon,,Donald Trump. Michael R,Republican,883,82048
-Essex,President,,Maidstone,,Donald Trump. Michael R,Republican,60,82048
-Bennington,President,,Manchester,,Donald Trump. Michael R,Republican,706,82048
-Windham,President,,Marlboro,,Donald Trump. Michael R,Republican,90,82048
-Washington,President,,Marshfield,,Donald Trump. Michael R,Republican,284,82048
-Rutland,President,,Mendon,,Donald Trump. Michael R,Republican,268,82048
-Addison,President,,Middlebury,,Donald Trump. Michael R,Republican,595,82048
-Washington,President,,Middlesex,,Donald Trump. Michael R,Republican,228,82048
-Rutland,President,,Middletown Springs,,Donald Trump. Michael R,Republican,179,82048
-Chittenden,President,,Milton,Chittenden 10,Donald Trump. Michael R,Republican,1783,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Donald Trump. Michael R,Republican,302,82048
-Addison,President,,Monkton,,Donald Trump. Michael R,Republican,360,82048
-Franklin,President,,Montgomery,,Donald Trump. Michael R,Republican,231,82048
-Washington,President,,Montpelier,,Donald Trump. Michael R,Republican,492,82048
-Washington,President,,Moretown,,Donald Trump. Michael R,Republican,216,82048
-Orleans,President,,Morgan,,Donald Trump. Michael R,Republican,197,82048
-Lamoille,President,,Morristown,,Donald Trump. Michael R,Republican,741,82048
-Rutland,President,,Mount Holly,,Donald Trump. Michael R,Republican,325,82048
-Rutland,President,,Mount Tabor,,Donald Trump. Michael R,Republican,42,82048
-Addison,President,,New Haven,,Donald Trump. Michael R,Republican,337,82048
-Caledonia,President,,Newark,,Donald Trump. Michael R,Republican,116,82048
-Orange,President,,Newbury,,Donald Trump. Michael R,Republican,403,82048
-Windham,President,,Newfane,,Donald Trump. Michael R,Republican,209,82048
-Orleans,President,,Newport City,,Donald Trump. Michael R,Republican,614,82048
-Orleans,President,,Newport Town,,Donald Trump. Michael R,Republican,338,82048
-Grand Isle,President,,North Hero,,Donald Trump. Michael R,Republican,216,82048
-Washington,President,,Northfield,,Donald Trump. Michael R,Republican,708,82048
-Essex,President,,Norton,,Donald Trump. Michael R,Republican,46,82048
-Windsor,President,,Norwich,,Donald Trump. Michael R,Republican,191,82048
-Orange,President,,Orange,,Donald Trump. Michael R,Republican,265,82048
-Addison,President,,Orwell,,Donald Trump. Michael R,Republican,284,82048
-Addison,President,,Panton,,Donald Trump. Michael R,Republican,126,82048
-Rutland,President,,Pawlet,,Donald Trump. Michael R,Republican,311,82048
-Caledonia,President,,Peacham,,Donald Trump. Michael R,Republican,113,82048
-Bennington,President,,Peru,,Donald Trump. Michael R,Republican,54,82048
-Rutland,President,,Pittsfield,,Donald Trump. Michael R,Republican,114,82048
-Rutland,President,,Pittsford,,Donald Trump. Michael R,Republican,669,82048
-Washington,President,,Plainfield,,Donald Trump. Michael R,Republican,129,82048
-Windsor,President,,Plymouth,,Donald Trump. Michael R,Republican,125,82048
-Windsor,President,,Pomfret,,Donald Trump. Michael R,Republican,130,82048
-Rutland,President,,Poultney,,Donald Trump. Michael R,Republican,599,82048
-Bennington,President,,Pownal,,Donald Trump. Michael R,Republican,681,82048
-Rutland,President,,Proctor,,Donald Trump. Michael R,Republican,339,82048
-Windham,President,,Putney,,Donald Trump. Michael R,Republican,175,82048
-Orange,President,,Randolph,,Donald Trump. Michael R,Republican,737,82048
-Windsor,President,,Reading,,Donald Trump. Michael R,Republican,108,82048
-Bennington,President,,Readsboro,,Donald Trump. Michael R,Republican,173,82048
-Franklin,President,,Richford,,Donald Trump. Michael R,Republican,388,82048
-Chittenden,President,,Richmond,,Donald Trump. Michael R,Republican,515,82048
-Addison,President,,Ripton,,Donald Trump. Michael R,Republican,58,82048
-Windsor,President,,Rochester,,Donald Trump. Michael R,Republican,162,82048
-Windham,President,,Rockingham,,Donald Trump. Michael R,Republican,576,82048
-Washington,President,,Roxbury,,Donald Trump. Michael R,Republican,118,82048
-Windsor,President,,Royalton,,Donald Trump. Michael R,Republican,406,82048
-Bennington,President,,Rupert,,Donald Trump. Michael R,Republican,138,82048
-Rutland,President,,Rutland City,Rutland 5-1,Donald Trump. Michael R,Republican,845,82048
-Rutland,President,,Rutland City,Rutland 5-2,Donald Trump. Michael R,Republican,704,82048
-Rutland,President,,Rutland City,Rutland 5-3,Donald Trump. Michael R,Republican,557,82048
-Rutland,President,,Rutland City,Rutland 5-4,Donald Trump. Michael R,Republican,628,82048
-Rutland,President,,Rutland Town,,Donald Trump. Michael R,Republican,979,82048
-Caledonia,President,,Ryegate,,Donald Trump. Michael R,Republican,239,82048
-Addison,President,,Salisbury,,Donald Trump. Michael R,Republican,189,82048
-Bennington,President,,Sandgate,,Donald Trump. Michael R,Republican,95,82048
-Bennington,President,,Searsburg,,Donald Trump. Michael R,Republican,36,82048
-Bennington,President,,Shaftsbury,,Donald Trump. Michael R,Republican,661,82048
-Windsor,President,,Sharon,,Donald Trump. Michael R,Republican,217,82048
-Caledonia,President,,Sheffield,,Donald Trump. Michael R,Republican,131,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Donald Trump. Michael R,Republican,445,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Donald Trump. Michael R,Republican,496,82048
-Franklin,President,,Sheldon,,Donald Trump. Michael R,Republican,377,82048
-Addison,President,,Shoreham,,Donald Trump. Michael R,Republican,211,82048
-Rutland,President,,Shrewsbury,,Donald Trump. Michael R,Republican,269,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Donald Trump. Michael R,Republican,433,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Donald Trump. Michael R,Republican,652,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Donald Trump. Michael R,Republican,423,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Donald Trump. Michael R,Republican,551,82048
-Grand Isle,President,,South Hero,,Donald Trump. Michael R,Republican,301,82048
-Windsor,President,,Springfield,Windsor 3-1,Donald Trump. Michael R,Republican,65,82048
-Windsor,President,,Springfield,Windsor 3-2,Donald Trump. Michael R,Republican,1445,82048
-Franklin,President,,Saint Albans City,,Donald Trump. Michael R,Republican,807,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Donald Trump. Michael R,Republican,392,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Donald Trump. Michael R,Republican,876,82048
-Chittenden,President,,Saint George,,Donald Trump. Michael R,Republican,110,82048
-Caledonia,President,,Saint Johnsbury,,Donald Trump. Michael R,Republican,1110,82048
-Bennington,President,,Stamford,,Donald Trump. Michael R,Republican,238,82048
-Caledonia,President,,Stannard,,Donald Trump. Michael R,Republican,22,82048
-Addison,President,,Starksboro,,Donald Trump. Michael R,Republican,256,82048
-Windsor,President,,Stockbridge,,Donald Trump. Michael R,Republican,140,82048
-Lamoille,President,,Stowe,,Donald Trump. Michael R,Republican,559,82048
-Orange,President,,Strafford,,Donald Trump. Michael R,Republican,105,82048
-Windham,President,,Stratton,,Donald Trump. Michael R,Republican,50,82048
-Rutland,President,,Sudbury,,Donald Trump. Michael R,Republican,122,82048
-Bennington,President,,Sunderland,Bennington 3,Donald Trump. Michael R,Republican,41,82048
-Bennington,President,,Sunderland,Bennington 4,Donald Trump. Michael R,Republican,142,82048
-Caledonia,President,,Sutton,,Donald Trump. Michael R,Republican,220,82048
-Franklin,President,,Swanton,,Donald Trump. Michael R,Republican,1192,82048
-Orange,President,,Thetford,,Donald Trump. Michael R,Republican,324,82048
-Rutland,President,,Tinmouth,Rutland 2,Donald Trump. Michael R,Republican,32,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Donald Trump. Michael R,Republican,91,82048
-Orange,President,,Topsham,,Donald Trump. Michael R,Republican,274,82048
-Windham,President,,Townshend,,Donald Trump. Michael R,Republican,174,82048
-Orleans,President,,Troy,Orleans 2,Donald Trump. Michael R,Republican,75,82048
-Orleans,President,,Troy,Orleans-Lamoille,Donald Trump. Michael R,Republican,208,82048
-Orange,President,,Tunbridge,,Donald Trump. Michael R,Republican,242,82048
-Chittenden,President,,Underhill,,Donald Trump. Michael R,Republican,504,82048
-Addison,President,,Vergennes,,Donald Trump. Michael R,Republican,326,82048
-Windham,President,,Vernon,,Donald Trump. Michael R,Republican,486,82048
-Orange,President,,Vershire,,Donald Trump. Michael R,Republican,118,82048
-Essex,President,,Victory,,Donald Trump. Michael R,Republican,38,82048
-Washington,President,,Waitsfield,,Donald Trump. Michael R,Republican,210,82048
-Caledonia,President,,Walden,,Donald Trump. Michael R,Republican,168,82048
-Rutland,President,,Wallingford,,Donald Trump. Michael R,Republican,463,82048
-Addison,President,,Waltham,,Donald Trump. Michael R,Republican,83,82048
-Windham,President,,Wardsboro,,Donald Trump. Michael R,Republican,137,82048
-Washington,President,,Warren,,Donald Trump. Michael R,Republican,182,82048
-Orange,President,,Washington,,Donald Trump. Michael R,Republican,241,82048
-Washington,President,,Waterbury,,Donald Trump. Michael R,Republican,592,82048
-Caledonia,President,,Waterford,,Donald Trump. Michael R,Republican,341,82048
-Lamoille,President,,Waterville,,Donald Trump. Michael R,Republican,146,82048
-Windsor,President,,Weathersfield,,Donald Trump. Michael R,Republican,647,82048
-Rutland,President,,Wells,,Donald Trump. Michael R,Republican,312,82048
-Orange,President,,West Fairlee,,Donald Trump. Michael R,Republican,97,82048
-Rutland,President,,West Haven,,Donald Trump. Michael R,Republican,56,82048
-Rutland,President,,West Rutland,,Donald Trump. Michael R,Republican,541,82048
-Windsor,President,,West Windsor,,Donald Trump. Michael R,Republican,173,82048
-Orleans,President,,Westfield,,Donald Trump. Michael R,Republican,123,82048
-Chittenden,President,,Westford,,Donald Trump. Michael R,Republican,371,82048
-Windham,President,,Westminster,Windham 3,Donald Trump. Michael R,Republican,26,82048
-Windham,President,,Westminster,Windham 4,Donald Trump. Michael R,Republican,326,82048
-Orleans,President,,Westmore,,Donald Trump. Michael R,Republican,93,82048
-Windsor,President,,Weston,,Donald Trump. Michael R,Republican,106,82048
-Addison,President,,Weybridge,,Donald Trump. Michael R,Republican,74,82048
-Caledonia,President,,Wheelock,,Donald Trump. Michael R,Republican,175,82048
-Addison,President,,Whiting,,Donald Trump. Michael R,Republican,68,82048
-Windham,President,,Whitingham,Windham 6,Donald Trump. Michael R,Republican,270,82048
-Windham,President,,Whitingham,Windham-Bennington,Donald Trump. Michael R,Republican,15,82048
-Orange,President,,Williamstown,,Donald Trump. Michael R,Republican,658,82048
-Chittenden,President,,Williston,,Donald Trump. Michael R,Republican,1481,82048
-Windham,President,,Wilmington,,Donald Trump. Michael R,Republican,338,82048
-Windham,President,,Windham,,Donald Trump. Michael R,Republican,79,82048
-Windsor,President,,Windsor,,Donald Trump. Michael R,Republican,462,82048
-Bennington,President,,Winhall,,Donald Trump. Michael R,Republican,158,82048
-Chittenden,President,,Winooski,,Donald Trump. Michael R,Republican,536,82048
-Lamoille,President,,Wolcott,,Donald Trump. Michael R,Republican,276,82048
-Washington,President,,Woodbury,,Donald Trump. Michael R,Republican,169,82048
-Bennington,President,,Woodford,,Donald Trump. Michael R,Republican,66,82048
-Windsor,President,,Woodstock,,Donald Trump. Michael R,Republican,372,82048
-Washington,President,,Worcester,,Donald Trump. Michael R,Republican,117,82048
+Addison,President,,Addison,,Hillary Clinton,Democratic,324,82048
+Orleans,President,,Albany,,Hillary Clinton,Democratic,207,82048
+Grand Isle,President,,Alburgh,,Hillary Clinton,Democratic,372,82048
+Windsor,President,,Andover,,Hillary Clinton,Democratic,166,82048
+Bennington,President,,Arlington,,Hillary Clinton,Democratic,662,82048
+Windham,President,,Athens,,Hillary Clinton,Democratic,69,82048
+Franklin,President,,Bakersfield,,Hillary Clinton,Democratic,295,82048
+Windsor,President,,Baltimore,,Hillary Clinton,Democratic,50,82048
+Windsor,President,,Barnard,,Hillary Clinton,Democratic,339,82048
+Caledonia,President,,Barnet,,Hillary Clinton,Democratic,485,82048
+Washington,President,,Barre City,,Hillary Clinton,Democratic,1653,82048
+Washington,President,,Barre Town,,Hillary Clinton,Democratic,1760,82048
+Orleans,President,,Barton,,Hillary Clinton,Democratic,502,82048
+Lamoille,President,,Belvidere,,Hillary Clinton,Democratic,53,82048
+Bennington,President,,Bennington,Bennington 2-1,Hillary Clinton,Democratic,1764,82048
+Bennington,President,,Bennington,Bennington 2-2,Hillary Clinton,Democratic,1597,82048
+Rutland,President,,Benson,,Hillary Clinton,Democratic,216,82048
+Franklin,President,,Berkshire,,Hillary Clinton,Democratic,209,82048
+Washington,President,,Berlin,,Hillary Clinton,Democratic,658,82048
+Windsor,President,,Bethel,,Hillary Clinton,Democratic,543,82048
+Essex,President,,Bloomfield,,Hillary Clinton,Democratic,30,82048
+Chittenden,President,,Bolton,,Hillary Clinton,Democratic,389,82048
+Orange,President,,Bradford,,Hillary Clinton,Democratic,624,82048
+Orange,President,,Braintree,,Hillary Clinton,Democratic,289,82048
+Rutland,President,,Brandon,,Hillary Clinton,Democratic,924,82048
+Windham,President,,Brattleboro,Windham 2-1,Hillary Clinton,Democratic,1489,82048
+Windham,President,,Brattleboro,Windham 2-2,Hillary Clinton,Democratic,1367,82048
+Windham,President,,Brattleboro,Windham 2-3,Hillary Clinton,Democratic,1491,82048
+Windsor,President,,Bridgewater,,Hillary Clinton,Democratic,280,82048
+Addison,President,,Bridport,,Hillary Clinton,Democratic,292,82048
+Essex,President,,Brighton,,Hillary Clinton,Democratic,229,82048
+Addison,President,,Bristol,,Hillary Clinton,Democratic,1075,82048
+Orange,President,,Brookfield,,Hillary Clinton,Democratic,378,82048
+Windham,President,,Brookline,,Hillary Clinton,Democratic,169,82048
+Orleans,President,,Brownington,,Hillary Clinton,Democratic,146,82048
+Essex,President,,Brunswick,,Hillary Clinton,Democratic,21,82048
+Caledonia,President,,Burke,,Hillary Clinton,Democratic,381,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Hillary Clinton,Democratic,3023,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Hillary Clinton,Democratic,1697,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Hillary Clinton,Democratic,2818,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Hillary Clinton,Democratic,2028,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Hillary Clinton,Democratic,3922,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Hillary Clinton,Democratic,933,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Hillary Clinton,Democratic,98,82048
+Washington,President,,Cabot,,Hillary Clinton,Democratic,394,82048
+Washington,President,,Calais,,Hillary Clinton,Democratic,688,82048
+Lamoille,President,,Cambridge,,Hillary Clinton,Democratic,1067,82048
+Essex,President,,Canaan,,Hillary Clinton,Democratic,179,82048
+Rutland,President,,Castleton,,Hillary Clinton,Democratic,795,82048
+Windsor,President,,Cavendish,,Hillary Clinton,Democratic,306,82048
+Orleans,President,,Charleston,,Hillary Clinton,Democratic,184,82048
+Chittenden,President,,Charlotte,,Hillary Clinton,Democratic,1794,82048
+Orange,President,,Chelsea,,Hillary Clinton,Democratic,304,82048
+Windsor,President,,Chester,,Hillary Clinton,Democratic,827,82048
+Rutland,President,,Chittenden,,Hillary Clinton,Democratic,352,82048
+Rutland,President,,Clarendon,,Hillary Clinton,Democratic,470,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Hillary Clinton,Democratic,1929,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Hillary Clinton,Democratic,2554,82048
+Essex,President,,Concord,,Hillary Clinton,Democratic,181,82048
+Orange,President,,Corinth,,Hillary Clinton,Democratic,308,82048
+Addison,President,,Cornwall,,Hillary Clinton,Democratic,517,82048
+Orleans,President,,Coventry,,Hillary Clinton,Democratic,196,82048
+Orleans,President,,Craftsbury,,Hillary Clinton,Democratic,435,82048
+Rutland,President,,Danby,,Hillary Clinton,Democratic,252,82048
+Caledonia,President,,Danville,,Hillary Clinton,Democratic,645,82048
+Orleans,President,,Derby,,Hillary Clinton,Democratic,885,82048
+Bennington,President,,Dorset,,Hillary Clinton,Democratic,740,82048
+Windham,President,,Dover,,Hillary Clinton,Democratic,409,82048
+Windham,President,,Dummerston,,Hillary Clinton,Democratic,797,82048
+Washington,President,,Duxbury,,Hillary Clinton,Democratic,434,82048
+Essex,President,,East Haven,,Hillary Clinton,Democratic,51,82048
+Washington,President,,East Montpelier,,Hillary Clinton,Democratic,1032,82048
+Lamoille,President,,Eden,,Hillary Clinton,Democratic,221,82048
+Lamoille,President,,Elmore,,Hillary Clinton,Democratic,339,82048
+Franklin,President,,Enosburgh,,Hillary Clinton,Democratic,502,82048
+Chittenden,President,,Essex,Chittenden 8-1,Hillary Clinton,Democratic,2847,82048
+Chittenden,President,,Essex,Chittenden 8-2,Hillary Clinton,Democratic,3057,82048
+Chittenden,President,,Essex,Chittenden 8-3,Hillary Clinton,Democratic,849,82048
+Rutland,President,,Fair Haven,,Hillary Clinton,Democratic,478,82048
+Franklin,President,,Fairfax,,Hillary Clinton,Democratic,1063,82048
+Franklin,President,,Fairfield,,Hillary Clinton,Democratic,489,82048
+Orange,President,,Fairlee,,Hillary Clinton,Democratic,350,82048
+Washington,President,,Fayston,,Hillary Clinton,Democratic,586,82048
+Addison,President,,Ferrisburgh,,Hillary Clinton,Democratic,892,82048
+Franklin,President,,Fletcher,,Hillary Clinton,Democratic,336,82048
+Franklin,President,,Franklin,,Hillary Clinton,Democratic,229,82048
+Franklin,President,,Georgia,,Hillary Clinton,Democratic,1019,82048
+Orleans,President,,Glover,,Hillary Clinton,Democratic,290,82048
+Addison,President,,Goshen,,Hillary Clinton,Democratic,78,82048
+Windham,President,,Grafton,,Hillary Clinton,Democratic,210,82048
+Essex,President,,Granby,,Hillary Clinton,Democratic,12,82048
+Grand Isle,President,,Grand Isle,,Hillary Clinton,Democratic,594,82048
+Addison,President,,Granville,,Hillary Clinton,Democratic,82,82048
+Orleans,President,,Greensboro,,Hillary Clinton,Democratic,271,82048
+Caledonia,President,,Groton,,Hillary Clinton,Democratic,159,82048
+Essex,President,,Guildhall,,Hillary Clinton,Democratic,40,82048
+Windham,President,,Guilford,,Hillary Clinton,Democratic,719,82048
+Windham,President,,Halifax,,Hillary Clinton,Democratic,202,82048
+Addison,President,,Hancock,,Hillary Clinton,Democratic,75,82048
+Caledonia,President,,Hardwick,,Hillary Clinton,Democratic,651,82048
+Windsor,President,,Hartford,Windsor 4-1,Hillary Clinton,Democratic,738,82048
+Windsor,President,,Hartford,Windsor 4-2,Hillary Clinton,Democratic,2452,82048
+Windsor,President,,Hartland,,Hillary Clinton,Democratic,1158,82048
+Franklin,President,,Highgate,,Hillary Clinton,Democratic,474,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Hillary Clinton,Democratic,15,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Hillary Clinton,Democratic,1711,82048
+Orleans,President,,Holland,,Hillary Clinton,Democratic,81,82048
+Rutland,President,,Hubbardton,,Hillary Clinton,Democratic,188,82048
+Chittenden,President,,Huntington,,Hillary Clinton,Democratic,796,82048
+Lamoille,President,,Hyde Park,,Hillary Clinton,Democratic,788,82048
+Rutland,President,,Ira,,Hillary Clinton,Democratic,102,82048
+Orleans,President,,Irasburg,,Hillary Clinton,Democratic,194,82048
+Grand Isle,President,,Isle La Motte,,Hillary Clinton,Democratic,136,82048
+Windham,President,,Jamaica,,Hillary Clinton,Democratic,311,82048
+Orleans,President,,Jay,,Hillary Clinton,Democratic,113,82048
+Chittenden,President,,Jericho,,Hillary Clinton,Democratic,2017,82048
+Lamoille,President,,Johnson,,Hillary Clinton,Democratic,691,82048
+Rutland,President,,Killington,,Hillary Clinton,Democratic,357,82048
+Caledonia,President,,Kirby,,Hillary Clinton,Democratic,125,82048
+Bennington,President,,Landgrove,,Hillary Clinton,Democratic,71,82048
+Addison,President,,Leicester,,Hillary Clinton,Democratic,217,82048
+Essex,President,,Lemington,,Hillary Clinton,Democratic,18,82048
+Addison,President,,Lincoln,,Hillary Clinton,Democratic,494,82048
+Windham,President,,Londonderry,,Hillary Clinton,Democratic,517,82048
+Orleans,President,,Lowell,,Hillary Clinton,Democratic,123,82048
+Windsor,President,,Ludlow,,Hillary Clinton,Democratic,538,82048
+Essex,President,,Lunenburg,,Hillary Clinton,Democratic,171,82048
+Caledonia,President,,Lyndon,,Hillary Clinton,Democratic,827,82048
+Essex,President,,Maidstone,,Hillary Clinton,Democratic,39,82048
+Bennington,President,,Manchester,,Hillary Clinton,Democratic,1452,82048
+Windham,President,,Marlboro,,Hillary Clinton,Democratic,432,82048
+Washington,President,,Marshfield,,Hillary Clinton,Democratic,417,82048
+Rutland,President,,Mendon,,Hillary Clinton,Democratic,302,82048
+Addison,President,,Middlebury,,Hillary Clinton,Democratic,2682,82048
+Washington,President,,Middlesex,,Hillary Clinton,Democratic,719,82048
+Rutland,President,,Middletown Springs,,Hillary Clinton,Democratic,233,82048
+Chittenden,President,,Milton,Chittenden 10,Hillary Clinton,Democratic,1950,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Hillary Clinton,Democratic,310,82048
+Addison,President,,Monkton,,Hillary Clinton,Democratic,671,82048
+Franklin,President,,Montgomery,,Hillary Clinton,Democratic,302,82048
+Washington,President,,Montpelier,,Hillary Clinton,Democratic,3698,82048
+Washington,President,,Moretown,,Hillary Clinton,Democratic,649,82048
+Orleans,President,,Morgan,,Hillary Clinton,Democratic,101,82048
+Lamoille,President,,Morristown,,Hillary Clinton,Democratic,1550,82048
+Rutland,President,,Mount Holly,,Hillary Clinton,Democratic,337,82048
+Rutland,President,,Mount Tabor,,Hillary Clinton,Democratic,45,82048
+Addison,President,,New Haven,,Hillary Clinton,Democratic,594,82048
+Caledonia,President,,Newark,,Hillary Clinton,Democratic,130,82048
+Orange,President,,Newbury,,Hillary Clinton,Democratic,528,82048
+Windham,President,,Newfane,,Hillary Clinton,Democratic,652,82048
+Orleans,President,,Newport City,,Hillary Clinton,Democratic,721,82048
+Orleans,President,,Newport Town,,Hillary Clinton,Democratic,256,82048
+Grand Isle,President,,North Hero,,Hillary Clinton,Democratic,320,82048
+Washington,President,,Northfield,,Hillary Clinton,Democratic,1113,82048
+Essex,President,,Norton,,Hillary Clinton,Democratic,30,82048
+Windsor,President,,Norwich,,Hillary Clinton,Democratic,1982,82048
+Orange,President,,Orange,,Hillary Clinton,Democratic,186,82048
+Addison,President,,Orwell,,Hillary Clinton,Democratic,270,82048
+Addison,President,,Panton,,Hillary Clinton,Democratic,171,82048
+Rutland,President,,Pawlet,,Hillary Clinton,Democratic,368,82048
+Caledonia,President,,Peacham,,Hillary Clinton,Democratic,291,82048
+Bennington,President,,Peru,,Hillary Clinton,Democratic,166,82048
+Rutland,President,,Pittsfield,,Hillary Clinton,Democratic,147,82048
+Rutland,President,,Pittsford,,Hillary Clinton,Democratic,668,82048
+Washington,President,,Plainfield,,Hillary Clinton,Democratic,424,82048
+Windsor,President,,Plymouth,,Hillary Clinton,Democratic,173,82048
+Windsor,President,,Pomfret,,Hillary Clinton,Democratic,395,82048
+Rutland,President,,Poultney,,Hillary Clinton,Democratic,652,82048
+Bennington,President,,Pownal,,Hillary Clinton,Democratic,761,82048
+Rutland,President,,Proctor,,Hillary Clinton,Democratic,385,82048
+Windham,President,,Putney,,Hillary Clinton,Democratic,992,82048
+Orange,President,,Randolph,,Hillary Clinton,Democratic,1160,82048
+Windsor,President,,Reading,,Hillary Clinton,Democratic,231,82048
+Bennington,President,,Readsboro,,Hillary Clinton,Democratic,166,82048
+Franklin,President,,Richford,,Hillary Clinton,Democratic,324,82048
+Chittenden,President,,Richmond,,Hillary Clinton,Democratic,1694,82048
+Addison,President,,Ripton,,Hillary Clinton,Democratic,228,82048
+Windsor,President,,Rochester,,Hillary Clinton,Democratic,393,82048
+Windham,President,,Rockingham,,Hillary Clinton,Democratic,1315,82048
+Washington,President,,Roxbury,,Hillary Clinton,Democratic,186,82048
+Windsor,President,,Royalton,,Hillary Clinton,Democratic,698,82048
+Bennington,President,,Rupert,,Hillary Clinton,Democratic,213,82048
+Rutland,President,,Rutland City,Rutland 5-1,Hillary Clinton,Democratic,1162,82048
+Rutland,President,,Rutland City,Rutland 5-2,Hillary Clinton,Democratic,911,82048
+Rutland,President,,Rutland City,Rutland 5-3,Hillary Clinton,Democratic,587,82048
+Rutland,President,,Rutland City,Rutland 5-4,Hillary Clinton,Democratic,835,82048
+Rutland,President,,Rutland Town,,Hillary Clinton,Democratic,1064,82048
+Caledonia,President,,Ryegate,,Hillary Clinton,Democratic,252,82048
+Addison,President,,Salisbury,,Hillary Clinton,Democratic,296,82048
+Bennington,President,,Sandgate,,Hillary Clinton,Democratic,99,82048
+Bennington,President,,Searsburg,,Hillary Clinton,Democratic,19,82048
+Bennington,President,,Shaftsbury,,Hillary Clinton,Democratic,952,82048
+Windsor,President,,Sharon,,Hillary Clinton,Democratic,428,82048
+Caledonia,President,,Sheffield,,Hillary Clinton,Democratic,110,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Hillary Clinton,Democratic,1930,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Hillary Clinton,Democratic,1460,82048
+Franklin,President,,Sheldon,,Hillary Clinton,Democratic,305,82048
+Addison,President,,Shoreham,,Hillary Clinton,Democratic,356,82048
+Rutland,President,,Shrewsbury,,Hillary Clinton,Democratic,325,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Hillary Clinton,Democratic,1899,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Hillary Clinton,Democratic,2064,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Hillary Clinton,Democratic,1810,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Hillary Clinton,Democratic,1473,82048
+Grand Isle,President,,South Hero,,Hillary Clinton,Democratic,672,82048
+Windsor,President,,Springfield,Windsor 3-1,Hillary Clinton,Democratic,71,82048
+Windsor,President,,Springfield,Windsor 3-2,Hillary Clinton,Democratic,1802,82048
+Franklin,President,,Saint Albans City,,Hillary Clinton,Democratic,1287,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Hillary Clinton,Democratic,465,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Hillary Clinton,Democratic,951,82048
+Chittenden,President,,Saint George,,Hillary Clinton,Democratic,200,82048
+Caledonia,President,,Saint Johnsbury,,Hillary Clinton,Democratic,1469,82048
+Bennington,President,,Stamford,,Hillary Clinton,Democratic,203,82048
+Caledonia,President,,Stannard,,Hillary Clinton,Democratic,58,82048
+Addison,President,,Starksboro,,Hillary Clinton,Democratic,534,82048
+Windsor,President,,Stockbridge,,Hillary Clinton,Democratic,222,82048
+Lamoille,President,,Stowe,,Hillary Clinton,Democratic,1974,82048
+Orange,President,,Strafford,,Hillary Clinton,Democratic,500,82048
+Windham,President,,Stratton,,Hillary Clinton,Democratic,65,82048
+Rutland,President,,Sudbury,,Hillary Clinton,Democratic,163,82048
+Bennington,President,,Sunderland,Bennington 3,Hillary Clinton,Democratic,62,82048
+Bennington,President,,Sunderland,Bennington 4,Hillary Clinton,Democratic,219,82048
+Caledonia,President,,Sutton,,Hillary Clinton,Democratic,168,82048
+Franklin,President,,Swanton,,Hillary Clinton,Democratic,1101,82048
+Orange,President,,Thetford,,Hillary Clinton,Democratic,1145,82048
+Rutland,President,,Tinmouth,Rutland 2,Hillary Clinton,Democratic,34,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Hillary Clinton,Democratic,105,82048
+Orange,President,,Topsham,,Hillary Clinton,Democratic,226,82048
+Windham,President,,Townshend,,Hillary Clinton,Democratic,412,82048
+Orleans,President,,Troy,Orleans 2,Hillary Clinton,Democratic,63,82048
+Orleans,President,,Troy,Orleans-Lamoille,Hillary Clinton,Democratic,180,82048
+Orange,President,,Tunbridge,,Hillary Clinton,Democratic,349,82048
+Chittenden,President,,Underhill,,Hillary Clinton,Democratic,1238,82048
+Addison,President,,Vergennes,,Hillary Clinton,Democratic,712,82048
+Windham,President,,Vernon,,Hillary Clinton,Democratic,492,82048
+Orange,President,,Vershire,,Hillary Clinton,Democratic,189,82048
+Essex,President,,Victory,,Hillary Clinton,Democratic,18,82048
+Washington,President,,Waitsfield,,Hillary Clinton,Democratic,751,82048
+Caledonia,President,,Walden,,Hillary Clinton,Democratic,246,82048
+Rutland,President,,Wallingford,,Hillary Clinton,Democratic,529,82048
+Addison,President,,Waltham,,Hillary Clinton,Democratic,149,82048
+Windham,President,,Wardsboro,,Hillary Clinton,Democratic,199,82048
+Washington,President,,Warren,,Hillary Clinton,Democratic,752,82048
+Orange,President,,Washington,,Hillary Clinton,Democratic,217,82048
+Washington,President,,Waterbury,,Hillary Clinton,Democratic,2035,82048
+Caledonia,President,,Waterford,,Hillary Clinton,Democratic,292,82048
+Lamoille,President,,Waterville,,Hillary Clinton,Democratic,161,82048
+Windsor,President,,Weathersfield,,Hillary Clinton,Democratic,745,82048
+Rutland,President,,Wells,,Hillary Clinton,Democratic,209,82048
+Orange,President,,West Fairlee,,Hillary Clinton,Democratic,161,82048
+Rutland,President,,West Haven,,Hillary Clinton,Democratic,56,82048
+Rutland,President,,West Rutland,,Hillary Clinton,Democratic,384,82048
+Windsor,President,,West Windsor,,Hillary Clinton,Democratic,469,82048
+Orleans,President,,Westfield,,Hillary Clinton,Democratic,134,82048
+Chittenden,President,,Westford,,Hillary Clinton,Democratic,696,82048
+Windham,President,,Westminster,Windham 3,Hillary Clinton,Democratic,41,82048
+Windham,President,,Westminster,Windham 4,Hillary Clinton,Democratic,960,82048
+Orleans,President,,Westmore,,Hillary Clinton,Democratic,103,82048
+Windsor,President,,Weston,,Hillary Clinton,Democratic,267,82048
+Addison,President,,Weybridge,,Hillary Clinton,Democratic,415,82048
+Caledonia,President,,Wheelock,,Hillary Clinton,Democratic,156,82048
+Addison,President,,Whiting,,Hillary Clinton,Democratic,95,82048
+Windham,President,,Whitingham,Windham 6,Hillary Clinton,Democratic,268,82048
+Windham,President,,Whitingham,Windham-Bennington,Hillary Clinton,Democratic,15,82048
+Orange,President,,Williamstown,,Hillary Clinton,Democratic,627,82048
+Chittenden,President,,Williston,,Hillary Clinton,Democratic,3508,82048
+Windham,President,,Wilmington,,Hillary Clinton,Democratic,591,82048
+Windham,President,,Windham,,Hillary Clinton,Democratic,156,82048
+Windsor,President,,Windsor,,Hillary Clinton,Democratic,964,82048
+Bennington,President,,Winhall,,Hillary Clinton,Democratic,299,82048
+Chittenden,President,,Winooski,,Hillary Clinton,Democratic,2105,82048
+Lamoille,President,,Wolcott,,Hillary Clinton,Democratic,397,82048
+Washington,President,,Woodbury,,Hillary Clinton,Democratic,271,82048
+Bennington,President,,Woodford,,Hillary Clinton,Democratic,94,82048
+Windsor,President,,Woodstock,,Hillary Clinton,Democratic,1319,82048
+Washington,President,,Worcester,,Hillary Clinton,Democratic,374,82048
+Addison,President,,Addison,,Donald Trump,Republican,337,82048
+Orleans,President,,Albany,,Donald Trump,Republican,183,82048
+Grand Isle,President,,Alburgh,,Donald Trump,Republican,399,82048
+Windsor,President,,Andover,,Donald Trump,Republican,125,82048
+Bennington,President,,Arlington,,Donald Trump,Republican,435,82048
+Windham,President,,Athens,,Donald Trump,Republican,61,82048
+Franklin,President,,Bakersfield,,Donald Trump,Republican,209,82048
+Windsor,President,,Baltimore,,Donald Trump,Republican,60,82048
+Windsor,President,,Barnard,,Donald Trump,Republican,174,82048
+Caledonia,President,,Barnet,,Donald Trump,Republican,355,82048
+Washington,President,,Barre City,,Donald Trump,Republican,1091,82048
+Washington,President,,Barre Town,,Donald Trump,Republican,1862,82048
+Orleans,President,,Barton,,Donald Trump,Republican,425,82048
+Lamoille,President,,Belvidere,,Donald Trump,Republican,85,82048
+Bennington,President,,Bennington,Bennington 2-1,Donald Trump,Republican,970,82048
+Bennington,President,,Bennington,Bennington 2-2,Donald Trump,Republican,979,82048
+Rutland,President,,Benson,,Donald Trump,Republican,232,82048
+Franklin,President,,Berkshire,,Donald Trump,Republican,308,82048
+Washington,President,,Berlin,,Donald Trump,Republican,454,82048
+Windsor,President,,Bethel,,Donald Trump,Republican,299,82048
+Essex,President,,Bloomfield,,Donald Trump,Republican,52,82048
+Chittenden,President,,Bolton,,Donald Trump,Republican,205,82048
+Orange,President,,Bradford,,Donald Trump,Republican,409,82048
+Orange,President,,Braintree,,Donald Trump,Republican,217,82048
+Rutland,President,,Brandon,,Donald Trump,Republican,723,82048
+Windham,President,,Brattleboro,Windham 2-1,Donald Trump,Republican,426,82048
+Windham,President,,Brattleboro,Windham 2-2,Donald Trump,Republican,216,82048
+Windham,President,,Brattleboro,Windham 2-3,Donald Trump,Republican,217,82048
+Windsor,President,,Bridgewater,,Donald Trump,Republican,160,82048
+Addison,President,,Bridport,,Donald Trump,Republican,278,82048
+Essex,President,,Brighton,,Donald Trump,Republican,276,82048
+Addison,President,,Bristol,,Donald Trump,Republican,558,82048
+Orange,President,,Brookfield,,Donald Trump,Republican,231,82048
+Windham,President,,Brookline,,Donald Trump,Republican,68,82048
+Orleans,President,,Brownington,,Donald Trump,Republican,193,82048
+Essex,President,,Brunswick,,Donald Trump,Republican,28,82048
+Caledonia,President,,Burke,,Donald Trump,Republican,336,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Donald Trump,Republican,855,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Donald Trump,Republican,278,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Donald Trump,Republican,258,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Donald Trump,Republican,150,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Donald Trump,Republican,460,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Donald Trump,Republican,74,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Donald Trump,Republican,7,82048
+Washington,President,,Cabot,,Donald Trump,Republican,252,82048
+Washington,President,,Calais,,Donald Trump,Republican,195,82048
+Lamoille,President,,Cambridge,,Donald Trump,Republican,520,82048
+Essex,President,,Canaan,,Donald Trump,Republican,207,82048
+Rutland,President,,Castleton,,Donald Trump,Republican,808,82048
+Windsor,President,,Cavendish,,Donald Trump,Republican,262,82048
+Orleans,President,,Charleston,,Donald Trump,Republican,210,82048
+Chittenden,President,,Charlotte,,Donald Trump,Republican,512,82048
+Orange,President,,Chelsea,,Donald Trump,Republican,273,82048
+Windsor,President,,Chester,,Donald Trump,Republican,512,82048
+Rutland,President,,Chittenden,,Donald Trump,Republican,312,82048
+Rutland,President,,Clarendon,,Donald Trump,Republican,641,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Donald Trump,Republican,988,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Donald Trump,Republican,1437,82048
+Essex,President,,Concord,,Donald Trump,Republican,292,82048
+Orange,President,,Corinth,,Donald Trump,Republican,264,82048
+Addison,President,,Cornwall,,Donald Trump,Republican,147,82048
+Orleans,President,,Coventry,,Donald Trump,Republican,244,82048
+Orleans,President,,Craftsbury,,Donald Trump,Republican,153,82048
+Rutland,President,,Danby,,Donald Trump,Republican,291,82048
+Caledonia,President,,Danville,,Donald Trump,Republican,494,82048
+Orleans,President,,Derby,,Donald Trump,Republican,1004,82048
+Bennington,President,,Dorset,,Donald Trump,Republican,334,82048
+Windham,President,,Dover,,Donald Trump,Republican,279,82048
+Windham,President,,Dummerston,,Donald Trump,Republican,213,82048
+Washington,President,,Duxbury,,Donald Trump,Republican,196,82048
+Essex,President,,East Haven,,Donald Trump,Republican,70,82048
+Washington,President,,East Montpelier,,Donald Trump,Republican,356,82048
+Lamoille,President,,Eden,,Donald Trump,Republican,241,82048
+Lamoille,President,,Elmore,,Donald Trump,Republican,132,82048
+Franklin,President,,Enosburgh,,Donald Trump,Republican,429,82048
+Chittenden,President,,Essex,Chittenden 8-1,Donald Trump,Republican,1274,82048
+Chittenden,President,,Essex,Chittenden 8-2,Donald Trump,Republican,1331,82048
+Chittenden,President,,Essex,Chittenden 8-3,Donald Trump,Republican,425,82048
+Rutland,President,,Fair Haven,,Donald Trump,Republican,529,82048
+Franklin,President,,Fairfax,,Donald Trump,Republican,947,82048
+Franklin,President,,Fairfield,,Donald Trump,Republican,338,82048
+Orange,President,,Fairlee,,Donald Trump,Republican,149,82048
+Washington,President,,Fayston,,Donald Trump,Republican,142,82048
+Addison,President,,Ferrisburgh,,Donald Trump,Republican,501,82048
+Franklin,President,,Fletcher,,Donald Trump,Republican,240,82048
+Franklin,President,,Franklin,,Donald Trump,Republican,296,82048
+Franklin,President,,Georgia,,Donald Trump,Republican,1023,82048
+Orleans,President,,Glover,,Donald Trump,Republican,193,82048
+Addison,President,,Goshen,,Donald Trump,Republican,31,82048
+Windham,President,,Grafton,,Donald Trump,Republican,131,82048
+Essex,President,,Granby,,Donald Trump,Republican,22,82048
+Grand Isle,President,,Grand Isle,,Donald Trump,Republican,431,82048
+Addison,President,,Granville,,Donald Trump,Republican,29,82048
+Orleans,President,,Greensboro,,Donald Trump,Republican,96,82048
+Caledonia,President,,Groton,,Donald Trump,Republican,234,82048
+Essex,President,,Guildhall,,Donald Trump,Republican,76,82048
+Windham,President,,Guilford,,Donald Trump,Republican,274,82048
+Windham,President,,Halifax,,Donald Trump,Republican,183,82048
+Addison,President,,Hancock,,Donald Trump,Republican,54,82048
+Caledonia,President,,Hardwick,,Donald Trump,Republican,501,82048
+Windsor,President,,Hartford,Windsor 4-1,Donald Trump,Republican,356,82048
+Windsor,President,,Hartford,Windsor 4-2,Donald Trump,Republican,947,82048
+Windsor,President,,Hartland,,Donald Trump,Republican,558,82048
+Franklin,President,,Highgate,,Donald Trump,Republican,699,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Donald Trump,Republican,4,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Donald Trump,Republican,619,82048
+Orleans,President,,Holland,,Donald Trump,Republican,175,82048
+Rutland,President,,Hubbardton,,Donald Trump,Republican,163,82048
+Chittenden,President,,Huntington,,Donald Trump,Republican,232,82048
+Lamoille,President,,Hyde Park,,Donald Trump,Republican,475,82048
+Rutland,President,,Ira,,Donald Trump,Republican,103,82048
+Orleans,President,,Irasburg,,Donald Trump,Republican,284,82048
+Grand Isle,President,,Isle La Motte,,Donald Trump,Republican,140,82048
+Windham,President,,Jamaica,,Donald Trump,Republican,132,82048
+Orleans,President,,Jay,,Donald Trump,Republican,101,82048
+Chittenden,President,,Jericho,,Donald Trump,Republican,890,82048
+Lamoille,President,,Johnson,,Donald Trump,Republican,395,82048
+Rutland,President,,Killington,,Donald Trump,Republican,232,82048
+Caledonia,President,,Kirby,,Donald Trump,Republican,96,82048
+Bennington,President,,Landgrove,,Donald Trump,Republican,18,82048
+Addison,President,,Leicester,,Donald Trump,Republican,207,82048
+Essex,President,,Lemington,,Donald Trump,Republican,28,82048
+Addison,President,,Lincoln,,Donald Trump,Republican,188,82048
+Windham,President,,Londonderry,,Donald Trump,Republican,303,82048
+Orleans,President,,Lowell,,Donald Trump,Republican,250,82048
+Windsor,President,,Ludlow,,Donald Trump,Republican,403,82048
+Essex,President,,Lunenburg,,Donald Trump,Republican,311,82048
+Caledonia,President,,Lyndon,,Donald Trump,Republican,883,82048
+Essex,President,,Maidstone,,Donald Trump,Republican,60,82048
+Bennington,President,,Manchester,,Donald Trump,Republican,706,82048
+Windham,President,,Marlboro,,Donald Trump,Republican,90,82048
+Washington,President,,Marshfield,,Donald Trump,Republican,284,82048
+Rutland,President,,Mendon,,Donald Trump,Republican,268,82048
+Addison,President,,Middlebury,,Donald Trump,Republican,595,82048
+Washington,President,,Middlesex,,Donald Trump,Republican,228,82048
+Rutland,President,,Middletown Springs,,Donald Trump,Republican,179,82048
+Chittenden,President,,Milton,Chittenden 10,Donald Trump,Republican,1783,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Donald Trump,Republican,302,82048
+Addison,President,,Monkton,,Donald Trump,Republican,360,82048
+Franklin,President,,Montgomery,,Donald Trump,Republican,231,82048
+Washington,President,,Montpelier,,Donald Trump,Republican,492,82048
+Washington,President,,Moretown,,Donald Trump,Republican,216,82048
+Orleans,President,,Morgan,,Donald Trump,Republican,197,82048
+Lamoille,President,,Morristown,,Donald Trump,Republican,741,82048
+Rutland,President,,Mount Holly,,Donald Trump,Republican,325,82048
+Rutland,President,,Mount Tabor,,Donald Trump,Republican,42,82048
+Addison,President,,New Haven,,Donald Trump,Republican,337,82048
+Caledonia,President,,Newark,,Donald Trump,Republican,116,82048
+Orange,President,,Newbury,,Donald Trump,Republican,403,82048
+Windham,President,,Newfane,,Donald Trump,Republican,209,82048
+Orleans,President,,Newport City,,Donald Trump,Republican,614,82048
+Orleans,President,,Newport Town,,Donald Trump,Republican,338,82048
+Grand Isle,President,,North Hero,,Donald Trump,Republican,216,82048
+Washington,President,,Northfield,,Donald Trump,Republican,708,82048
+Essex,President,,Norton,,Donald Trump,Republican,46,82048
+Windsor,President,,Norwich,,Donald Trump,Republican,191,82048
+Orange,President,,Orange,,Donald Trump,Republican,265,82048
+Addison,President,,Orwell,,Donald Trump,Republican,284,82048
+Addison,President,,Panton,,Donald Trump,Republican,126,82048
+Rutland,President,,Pawlet,,Donald Trump,Republican,311,82048
+Caledonia,President,,Peacham,,Donald Trump,Republican,113,82048
+Bennington,President,,Peru,,Donald Trump,Republican,54,82048
+Rutland,President,,Pittsfield,,Donald Trump,Republican,114,82048
+Rutland,President,,Pittsford,,Donald Trump,Republican,669,82048
+Washington,President,,Plainfield,,Donald Trump,Republican,129,82048
+Windsor,President,,Plymouth,,Donald Trump,Republican,125,82048
+Windsor,President,,Pomfret,,Donald Trump,Republican,130,82048
+Rutland,President,,Poultney,,Donald Trump,Republican,599,82048
+Bennington,President,,Pownal,,Donald Trump,Republican,681,82048
+Rutland,President,,Proctor,,Donald Trump,Republican,339,82048
+Windham,President,,Putney,,Donald Trump,Republican,175,82048
+Orange,President,,Randolph,,Donald Trump,Republican,737,82048
+Windsor,President,,Reading,,Donald Trump,Republican,108,82048
+Bennington,President,,Readsboro,,Donald Trump,Republican,173,82048
+Franklin,President,,Richford,,Donald Trump,Republican,388,82048
+Chittenden,President,,Richmond,,Donald Trump,Republican,515,82048
+Addison,President,,Ripton,,Donald Trump,Republican,58,82048
+Windsor,President,,Rochester,,Donald Trump,Republican,162,82048
+Windham,President,,Rockingham,,Donald Trump,Republican,576,82048
+Washington,President,,Roxbury,,Donald Trump,Republican,118,82048
+Windsor,President,,Royalton,,Donald Trump,Republican,406,82048
+Bennington,President,,Rupert,,Donald Trump,Republican,138,82048
+Rutland,President,,Rutland City,Rutland 5-1,Donald Trump,Republican,845,82048
+Rutland,President,,Rutland City,Rutland 5-2,Donald Trump,Republican,704,82048
+Rutland,President,,Rutland City,Rutland 5-3,Donald Trump,Republican,557,82048
+Rutland,President,,Rutland City,Rutland 5-4,Donald Trump,Republican,628,82048
+Rutland,President,,Rutland Town,,Donald Trump,Republican,979,82048
+Caledonia,President,,Ryegate,,Donald Trump,Republican,239,82048
+Addison,President,,Salisbury,,Donald Trump,Republican,189,82048
+Bennington,President,,Sandgate,,Donald Trump,Republican,95,82048
+Bennington,President,,Searsburg,,Donald Trump,Republican,36,82048
+Bennington,President,,Shaftsbury,,Donald Trump,Republican,661,82048
+Windsor,President,,Sharon,,Donald Trump,Republican,217,82048
+Caledonia,President,,Sheffield,,Donald Trump,Republican,131,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Donald Trump,Republican,445,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Donald Trump,Republican,496,82048
+Franklin,President,,Sheldon,,Donald Trump,Republican,377,82048
+Addison,President,,Shoreham,,Donald Trump,Republican,211,82048
+Rutland,President,,Shrewsbury,,Donald Trump,Republican,269,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Donald Trump,Republican,433,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Donald Trump,Republican,652,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Donald Trump,Republican,423,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Donald Trump,Republican,551,82048
+Grand Isle,President,,South Hero,,Donald Trump,Republican,301,82048
+Windsor,President,,Springfield,Windsor 3-1,Donald Trump,Republican,65,82048
+Windsor,President,,Springfield,Windsor 3-2,Donald Trump,Republican,1445,82048
+Franklin,President,,Saint Albans City,,Donald Trump,Republican,807,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Donald Trump,Republican,392,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Donald Trump,Republican,876,82048
+Chittenden,President,,Saint George,,Donald Trump,Republican,110,82048
+Caledonia,President,,Saint Johnsbury,,Donald Trump,Republican,1110,82048
+Bennington,President,,Stamford,,Donald Trump,Republican,238,82048
+Caledonia,President,,Stannard,,Donald Trump,Republican,22,82048
+Addison,President,,Starksboro,,Donald Trump,Republican,256,82048
+Windsor,President,,Stockbridge,,Donald Trump,Republican,140,82048
+Lamoille,President,,Stowe,,Donald Trump,Republican,559,82048
+Orange,President,,Strafford,,Donald Trump,Republican,105,82048
+Windham,President,,Stratton,,Donald Trump,Republican,50,82048
+Rutland,President,,Sudbury,,Donald Trump,Republican,122,82048
+Bennington,President,,Sunderland,Bennington 3,Donald Trump,Republican,41,82048
+Bennington,President,,Sunderland,Bennington 4,Donald Trump,Republican,142,82048
+Caledonia,President,,Sutton,,Donald Trump,Republican,220,82048
+Franklin,President,,Swanton,,Donald Trump,Republican,1192,82048
+Orange,President,,Thetford,,Donald Trump,Republican,324,82048
+Rutland,President,,Tinmouth,Rutland 2,Donald Trump,Republican,32,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Donald Trump,Republican,91,82048
+Orange,President,,Topsham,,Donald Trump,Republican,274,82048
+Windham,President,,Townshend,,Donald Trump,Republican,174,82048
+Orleans,President,,Troy,Orleans 2,Donald Trump,Republican,75,82048
+Orleans,President,,Troy,Orleans-Lamoille,Donald Trump,Republican,208,82048
+Orange,President,,Tunbridge,,Donald Trump,Republican,242,82048
+Chittenden,President,,Underhill,,Donald Trump,Republican,504,82048
+Addison,President,,Vergennes,,Donald Trump,Republican,326,82048
+Windham,President,,Vernon,,Donald Trump,Republican,486,82048
+Orange,President,,Vershire,,Donald Trump,Republican,118,82048
+Essex,President,,Victory,,Donald Trump,Republican,38,82048
+Washington,President,,Waitsfield,,Donald Trump,Republican,210,82048
+Caledonia,President,,Walden,,Donald Trump,Republican,168,82048
+Rutland,President,,Wallingford,,Donald Trump,Republican,463,82048
+Addison,President,,Waltham,,Donald Trump,Republican,83,82048
+Windham,President,,Wardsboro,,Donald Trump,Republican,137,82048
+Washington,President,,Warren,,Donald Trump,Republican,182,82048
+Orange,President,,Washington,,Donald Trump,Republican,241,82048
+Washington,President,,Waterbury,,Donald Trump,Republican,592,82048
+Caledonia,President,,Waterford,,Donald Trump,Republican,341,82048
+Lamoille,President,,Waterville,,Donald Trump,Republican,146,82048
+Windsor,President,,Weathersfield,,Donald Trump,Republican,647,82048
+Rutland,President,,Wells,,Donald Trump,Republican,312,82048
+Orange,President,,West Fairlee,,Donald Trump,Republican,97,82048
+Rutland,President,,West Haven,,Donald Trump,Republican,56,82048
+Rutland,President,,West Rutland,,Donald Trump,Republican,541,82048
+Windsor,President,,West Windsor,,Donald Trump,Republican,173,82048
+Orleans,President,,Westfield,,Donald Trump,Republican,123,82048
+Chittenden,President,,Westford,,Donald Trump,Republican,371,82048
+Windham,President,,Westminster,Windham 3,Donald Trump,Republican,26,82048
+Windham,President,,Westminster,Windham 4,Donald Trump,Republican,326,82048
+Orleans,President,,Westmore,,Donald Trump,Republican,93,82048
+Windsor,President,,Weston,,Donald Trump,Republican,106,82048
+Addison,President,,Weybridge,,Donald Trump,Republican,74,82048
+Caledonia,President,,Wheelock,,Donald Trump,Republican,175,82048
+Addison,President,,Whiting,,Donald Trump,Republican,68,82048
+Windham,President,,Whitingham,Windham 6,Donald Trump,Republican,270,82048
+Windham,President,,Whitingham,Windham-Bennington,Donald Trump,Republican,15,82048
+Orange,President,,Williamstown,,Donald Trump,Republican,658,82048
+Chittenden,President,,Williston,,Donald Trump,Republican,1481,82048
+Windham,President,,Wilmington,,Donald Trump,Republican,338,82048
+Windham,President,,Windham,,Donald Trump,Republican,79,82048
+Windsor,President,,Windsor,,Donald Trump,Republican,462,82048
+Bennington,President,,Winhall,,Donald Trump,Republican,158,82048
+Chittenden,President,,Winooski,,Donald Trump,Republican,536,82048
+Lamoille,President,,Wolcott,,Donald Trump,Republican,276,82048
+Washington,President,,Woodbury,,Donald Trump,Republican,169,82048
+Bennington,President,,Woodford,,Donald Trump,Republican,66,82048
+Windsor,President,,Woodstock,,Donald Trump,Republican,372,82048
+Washington,President,,Worcester,,Donald Trump,Republican,117,82048
 Addison,President,,Addison,,Bernie Sanders,,45,82048
 Orleans,President,,Albany,,Bernie Sanders,,31,82048
 Grand Isle,President,,Alburgh,,Bernie Sanders,,71,82048
@@ -11252,1106 +11252,1106 @@ Washington,President,,Woodbury,,Bernie Sanders,,44,82048
 Bennington,President,,Woodford,,Bernie Sanders,,8,82048
 Windsor,President,,Woodstock,,Bernie Sanders,,73,82048
 Washington,President,,Worcester,,Bernie Sanders,,48,82048
-Addison,President,,Addison,,Gary Johnson. William,Libertarian,47,82048
-Orleans,President,,Albany,,Gary Johnson. William,Libertarian,13,82048
-Grand Isle,President,,Alburgh,,Gary Johnson. William,Libertarian,29,82048
-Windsor,President,,Andover,,Gary Johnson. William,Libertarian,8,82048
-Bennington,President,,Arlington,,Gary Johnson. William,Libertarian,28,82048
-Windham,President,,Athens,,Gary Johnson. William,Libertarian,6,82048
-Franklin,President,,Bakersfield,,Gary Johnson. William,Libertarian,22,82048
-Windsor,President,,Baltimore,,Gary Johnson. William,Libertarian,9,82048
-Windsor,President,,Barnard,,Gary Johnson. William,Libertarian,13,82048
-Caledonia,President,,Barnet,,Gary Johnson. William,Libertarian,46,82048
-Washington,President,,Barre City,,Gary Johnson. William,Libertarian,109,82048
-Washington,President,,Barre Town,,Gary Johnson. William,Libertarian,139,82048
-Orleans,President,,Barton,,Gary Johnson. William,Libertarian,32,82048
-Lamoille,President,,Belvidere,,Gary Johnson. William,Libertarian,7,82048
-Bennington,President,,Bennington,Bennington 2-1,Gary Johnson. William,Libertarian,72,82048
-Bennington,President,,Bennington,Bennington 2-2,Gary Johnson. William,Libertarian,83,82048
-Rutland,President,,Benson,,Gary Johnson. William,Libertarian,23,82048
-Franklin,President,,Berkshire,,Gary Johnson. William,Libertarian,26,82048
-Washington,President,,Berlin,,Gary Johnson. William,Libertarian,51,82048
-Windsor,President,,Bethel,,Gary Johnson. William,Libertarian,33,82048
-Essex,President,,Bloomfield,,Gary Johnson. William,Libertarian,8,82048
-Chittenden,President,,Bolton,,Gary Johnson. William,Libertarian,14,82048
-Orange,President,,Bradford,,Gary Johnson. William,Libertarian,42,82048
-Orange,President,,Braintree,,Gary Johnson. William,Libertarian,21,82048
-Rutland,President,,Brandon,,Gary Johnson. William,Libertarian,49,82048
-Windham,President,,Brattleboro,Windham 2-1,Gary Johnson. William,Libertarian,31,82048
-Windham,President,,Brattleboro,Windham 2-2,Gary Johnson. William,Libertarian,32,82048
-Windham,President,,Brattleboro,Windham 2-3,Gary Johnson. William,Libertarian,32,82048
-Windsor,President,,Bridgewater,,Gary Johnson. William,Libertarian,11,82048
-Addison,President,,Bridport,,Gary Johnson. William,Libertarian,24,82048
-Essex,President,,Brighton,,Gary Johnson. William,Libertarian,17,82048
-Addison,President,,Bristol,,Gary Johnson. William,Libertarian,60,82048
-Orange,President,,Brookfield,,Gary Johnson. William,Libertarian,34,82048
-Windham,President,,Brookline,,Gary Johnson. William,Libertarian,12,82048
-Orleans,President,,Brownington,,Gary Johnson. William,Libertarian,8,82048
-Essex,President,,Brunswick,,Gary Johnson. William,Libertarian,2,82048
-Caledonia,President,,Burke,,Gary Johnson. William,Libertarian,34,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Gary Johnson. William,Libertarian,94,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Gary Johnson. William,Libertarian,52,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Gary Johnson. William,Libertarian,71,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Gary Johnson. William,Libertarian,44,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Gary Johnson. William,Libertarian,113,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Gary Johnson. William,Libertarian,34,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Gary Johnson. William,Libertarian,4,82048
-Washington,President,,Cabot,,Gary Johnson. William,Libertarian,37,82048
-Washington,President,,Calais,,Gary Johnson. William,Libertarian,21,82048
-Lamoille,President,,Cambridge,,Gary Johnson. William,Libertarian,89,82048
-Essex,President,,Canaan,,Gary Johnson. William,Libertarian,12,82048
-Rutland,President,,Castleton,,Gary Johnson. William,Libertarian,39,82048
-Windsor,President,,Cavendish,,Gary Johnson. William,Libertarian,20,82048
-Orleans,President,,Charleston,,Gary Johnson. William,Libertarian,17,82048
-Chittenden,President,,Charlotte,,Gary Johnson. William,Libertarian,79,82048
-Orange,President,,Chelsea,,Gary Johnson. William,Libertarian,22,82048
-Windsor,President,,Chester,,Gary Johnson. William,Libertarian,47,82048
-Rutland,President,,Chittenden,,Gary Johnson. William,Libertarian,21,82048
-Rutland,President,,Clarendon,,Gary Johnson. William,Libertarian,35,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Gary Johnson. William,Libertarian,107,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Gary Johnson. William,Libertarian,138,82048
-Essex,President,,Concord,,Gary Johnson. William,Libertarian,30,82048
-Orange,President,,Corinth,,Gary Johnson. William,Libertarian,19,82048
-Addison,President,,Cornwall,,Gary Johnson. William,Libertarian,22,82048
-Orleans,President,,Coventry,,Gary Johnson. William,Libertarian,16,82048
-Orleans,President,,Craftsbury,,Gary Johnson. William,Libertarian,26,82048
-Rutland,President,,Danby,,Gary Johnson. William,Libertarian,39,82048
-Caledonia,President,,Danville,,Gary Johnson. William,Libertarian,50,82048
-Orleans,President,,Derby,,Gary Johnson. William,Libertarian,82,82048
-Bennington,President,,Dorset,,Gary Johnson. William,Libertarian,36,82048
-Windham,President,,Dover,,Gary Johnson. William,Libertarian,24,82048
-Windham,President,,Dummerston,,Gary Johnson. William,Libertarian,31,82048
-Washington,President,,Duxbury,,Gary Johnson. William,Libertarian,38,82048
-Essex,President,,East Haven,,Gary Johnson. William,Libertarian,2,82048
-Washington,President,,East Montpelier,,Gary Johnson. William,Libertarian,41,82048
-Lamoille,President,,Eden,,Gary Johnson. William,Libertarian,17,82048
-Lamoille,President,,Elmore,,Gary Johnson. William,Libertarian,19,82048
-Franklin,President,,Enosburgh,,Gary Johnson. William,Libertarian,57,82048
-Chittenden,President,,Essex,Chittenden 8-1,Gary Johnson. William,Libertarian,168,82048
-Chittenden,President,,Essex,Chittenden 8-2,Gary Johnson. William,Libertarian,208,82048
-Chittenden,President,,Essex,Chittenden 8-3,Gary Johnson. William,Libertarian,42,82048
-Rutland,President,,Fair Haven,,Gary Johnson. William,Libertarian,23,82048
-Franklin,President,,Fairfax,,Gary Johnson. William,Libertarian,113,82048
-Franklin,President,,Fairfield,,Gary Johnson. William,Libertarian,41,82048
-Orange,President,,Fairlee,,Gary Johnson. William,Libertarian,17,82048
-Washington,President,,Fayston,,Gary Johnson. William,Libertarian,21,82048
-Addison,President,,Ferrisburgh,,Gary Johnson. William,Libertarian,61,82048
-Franklin,President,,Fletcher,,Gary Johnson. William,Libertarian,31,82048
-Franklin,President,,Franklin,,Gary Johnson. William,Libertarian,33,82048
-Franklin,President,,Georgia,,Gary Johnson. William,Libertarian,90,82048
-Orleans,President,,Glover,,Gary Johnson. William,Libertarian,31,82048
-Addison,President,,Goshen,,Gary Johnson. William,Libertarian,6,82048
-Windham,President,,Grafton,,Gary Johnson. William,Libertarian,14,82048
-Essex,President,,Granby,,Gary Johnson. William,Libertarian,1,82048
-Grand Isle,President,,Grand Isle,,Gary Johnson. William,Libertarian,39,82048
-Addison,President,,Granville,,Gary Johnson. William,Libertarian,3,82048
-Orleans,President,,Greensboro,,Gary Johnson. William,Libertarian,12,82048
-Caledonia,President,,Groton,,Gary Johnson. William,Libertarian,18,82048
-Essex,President,,Guildhall,,Gary Johnson. William,Libertarian,10,82048
-Windham,President,,Guilford,,Gary Johnson. William,Libertarian,29,82048
-Windham,President,,Halifax,,Gary Johnson. William,Libertarian,10,82048
-Addison,President,,Hancock,,Gary Johnson. William,Libertarian,6,82048
-Caledonia,President,,Hardwick,,Gary Johnson. William,Libertarian,42,82048
-Windsor,President,,Hartford,Windsor 4-1,Gary Johnson. William,Libertarian,51,82048
-Windsor,President,,Hartford,Windsor 4-2,Gary Johnson. William,Libertarian,123,82048
-Windsor,President,,Hartland,,Gary Johnson. William,Libertarian,52,82048
-Franklin,President,,Highgate,,Gary Johnson. William,Libertarian,42,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Gary Johnson. William,Libertarian,0,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Gary Johnson. William,Libertarian,81,82048
-Orleans,President,,Holland,,Gary Johnson. William,Libertarian,10,82048
-Rutland,President,,Hubbardton,,Gary Johnson. William,Libertarian,12,82048
-Chittenden,President,,Huntington,,Gary Johnson. William,Libertarian,44,82048
-Lamoille,President,,Hyde Park,,Gary Johnson. William,Libertarian,48,82048
-Rutland,President,,Ira,,Gary Johnson. William,Libertarian,8,82048
-Orleans,President,,Irasburg,,Gary Johnson. William,Libertarian,27,82048
-Grand Isle,President,,Isle La Motte,,Gary Johnson. William,Libertarian,12,82048
-Windham,President,,Jamaica,,Gary Johnson. William,Libertarian,24,82048
-Orleans,President,,Jay,,Gary Johnson. William,Libertarian,6,82048
-Chittenden,President,,Jericho,,Gary Johnson. William,Libertarian,101,82048
-Lamoille,President,,Johnson,,Gary Johnson. William,Libertarian,45,82048
-Rutland,President,,Killington,,Gary Johnson. William,Libertarian,29,82048
-Caledonia,President,,Kirby,,Gary Johnson. William,Libertarian,6,82048
-Bennington,President,,Landgrove,,Gary Johnson. William,Libertarian,5,82048
-Addison,President,,Leicester,,Gary Johnson. William,Libertarian,15,82048
-Essex,President,,Lemington,,Gary Johnson. William,Libertarian,6,82048
-Addison,President,,Lincoln,,Gary Johnson. William,Libertarian,22,82048
-Windham,President,,Londonderry,,Gary Johnson. William,Libertarian,30,82048
-Orleans,President,,Lowell,,Gary Johnson. William,Libertarian,11,82048
-Windsor,President,,Ludlow,,Gary Johnson. William,Libertarian,28,82048
-Essex,President,,Lunenburg,,Gary Johnson. William,Libertarian,20,82048
-Caledonia,President,,Lyndon,,Gary Johnson. William,Libertarian,86,82048
-Essex,President,,Maidstone,,Gary Johnson. William,Libertarian,6,82048
-Bennington,President,,Manchester,,Gary Johnson. William,Libertarian,74,82048
-Windham,President,,Marlboro,,Gary Johnson. William,Libertarian,5,82048
-Washington,President,,Marshfield,,Gary Johnson. William,Libertarian,27,82048
-Rutland,President,,Mendon,,Gary Johnson. William,Libertarian,26,82048
-Addison,President,,Middlebury,,Gary Johnson. William,Libertarian,77,82048
-Washington,President,,Middlesex,,Gary Johnson. William,Libertarian,31,82048
-Rutland,President,,Middletown Springs,,Gary Johnson. William,Libertarian,8,82048
-Chittenden,President,,Milton,Chittenden 10,Gary Johnson. William,Libertarian,123,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Gary Johnson. William,Libertarian,26,82048
-Addison,President,,Monkton,,Gary Johnson. William,Libertarian,57,82048
-Franklin,President,,Montgomery,,Gary Johnson. William,Libertarian,21,82048
-Washington,President,,Montpelier,,Gary Johnson. William,Libertarian,98,82048
-Washington,President,,Moretown,,Gary Johnson. William,Libertarian,42,82048
-Orleans,President,,Morgan,,Gary Johnson. William,Libertarian,10,82048
-Lamoille,President,,Morristown,,Gary Johnson. William,Libertarian,81,82048
-Rutland,President,,Mount Holly,,Gary Johnson. William,Libertarian,25,82048
-Rutland,President,,Mount Tabor,,Gary Johnson. William,Libertarian,5,82048
-Addison,President,,New Haven,,Gary Johnson. William,Libertarian,45,82048
-Caledonia,President,,Newark,,Gary Johnson. William,Libertarian,16,82048
-Orange,President,,Newbury,,Gary Johnson. William,Libertarian,28,82048
-Windham,President,,Newfane,,Gary Johnson. William,Libertarian,14,82048
-Orleans,President,,Newport City,,Gary Johnson. William,Libertarian,34,82048
-Orleans,President,,Newport Town,,Gary Johnson. William,Libertarian,31,82048
-Grand Isle,President,,North Hero,,Gary Johnson. William,Libertarian,15,82048
-Washington,President,,Northfield,,Gary Johnson. William,Libertarian,105,82048
-Essex,President,,Norton,,Gary Johnson. William,Libertarian,4,82048
-Windsor,President,,Norwich,,Gary Johnson. William,Libertarian,36,82048
-Orange,President,,Orange,,Gary Johnson. William,Libertarian,22,82048
-Addison,President,,Orwell,,Gary Johnson. William,Libertarian,29,82048
-Addison,President,,Panton,,Gary Johnson. William,Libertarian,6,82048
-Rutland,President,,Pawlet,,Gary Johnson. William,Libertarian,23,82048
-Caledonia,President,,Peacham,,Gary Johnson. William,Libertarian,25,82048
-Bennington,President,,Peru,,Gary Johnson. William,Libertarian,4,82048
-Rutland,President,,Pittsfield,,Gary Johnson. William,Libertarian,8,82048
-Rutland,President,,Pittsford,,Gary Johnson. William,Libertarian,65,82048
-Washington,President,,Plainfield,,Gary Johnson. William,Libertarian,16,82048
-Windsor,President,,Plymouth,,Gary Johnson. William,Libertarian,13,82048
-Windsor,President,,Pomfret,,Gary Johnson. William,Libertarian,21,82048
-Rutland,President,,Poultney,,Gary Johnson. William,Libertarian,49,82048
-Bennington,President,,Pownal,,Gary Johnson. William,Libertarian,47,82048
-Rutland,President,,Proctor,,Gary Johnson. William,Libertarian,34,82048
-Windham,President,,Putney,,Gary Johnson. William,Libertarian,32,82048
-Orange,President,,Randolph,,Gary Johnson. William,Libertarian,78,82048
-Windsor,President,,Reading,,Gary Johnson. William,Libertarian,11,82048
-Bennington,President,,Readsboro,,Gary Johnson. William,Libertarian,7,82048
-Franklin,President,,Richford,,Gary Johnson. William,Libertarian,21,82048
-Chittenden,President,,Richmond,,Gary Johnson. William,Libertarian,100,82048
-Addison,President,,Ripton,,Gary Johnson. William,Libertarian,5,82048
-Windsor,President,,Rochester,,Gary Johnson. William,Libertarian,17,82048
-Windham,President,,Rockingham,,Gary Johnson. William,Libertarian,75,82048
-Washington,President,,Roxbury,,Gary Johnson. William,Libertarian,21,82048
-Windsor,President,,Royalton,,Gary Johnson. William,Libertarian,46,82048
-Bennington,President,,Rupert,,Gary Johnson. William,Libertarian,14,82048
-Rutland,President,,Rutland City,Rutland 5-1,Gary Johnson. William,Libertarian,68,82048
-Rutland,President,,Rutland City,Rutland 5-2,Gary Johnson. William,Libertarian,44,82048
-Rutland,President,,Rutland City,Rutland 5-3,Gary Johnson. William,Libertarian,42,82048
-Rutland,President,,Rutland City,Rutland 5-4,Gary Johnson. William,Libertarian,55,82048
-Rutland,President,,Rutland Town,,Gary Johnson. William,Libertarian,88,82048
-Caledonia,President,,Ryegate,,Gary Johnson. William,Libertarian,15,82048
-Addison,President,,Salisbury,,Gary Johnson. William,Libertarian,8,82048
-Bennington,President,,Sandgate,,Gary Johnson. William,Libertarian,6,82048
-Bennington,President,,Searsburg,,Gary Johnson. William,Libertarian,0,82048
-Bennington,President,,Shaftsbury,,Gary Johnson. William,Libertarian,53,82048
-Windsor,President,,Sharon,,Gary Johnson. William,Libertarian,15,82048
-Caledonia,President,,Sheffield,,Gary Johnson. William,Libertarian,14,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Gary Johnson. William,Libertarian,51,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Gary Johnson. William,Libertarian,60,82048
-Franklin,President,,Sheldon,,Gary Johnson. William,Libertarian,31,82048
-Addison,President,,Shoreham,,Gary Johnson. William,Libertarian,19,82048
-Rutland,President,,Shrewsbury,,Gary Johnson. William,Libertarian,16,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Gary Johnson. William,Libertarian,67,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Gary Johnson. William,Libertarian,97,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Gary Johnson. William,Libertarian,69,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Gary Johnson. William,Libertarian,89,82048
-Grand Isle,President,,South Hero,,Gary Johnson. William,Libertarian,36,82048
-Windsor,President,,Springfield,Windsor 3-1,Gary Johnson. William,Libertarian,3,82048
-Windsor,President,,Springfield,Windsor 3-2,Gary Johnson. William,Libertarian,141,82048
-Franklin,President,,Saint Albans City,,Gary Johnson. William,Libertarian,120,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Gary Johnson. William,Libertarian,45,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Gary Johnson. William,Libertarian,61,82048
-Chittenden,President,,Saint George,,Gary Johnson. William,Libertarian,7,82048
-Caledonia,President,,Saint Johnsbury,,Gary Johnson. William,Libertarian,125,82048
-Bennington,President,,Stamford,,Gary Johnson. William,Libertarian,16,82048
-Caledonia,President,,Stannard,,Gary Johnson. William,Libertarian,5,82048
-Addison,President,,Starksboro,,Gary Johnson. William,Libertarian,36,82048
-Windsor,President,,Stockbridge,,Gary Johnson. William,Libertarian,7,82048
-Lamoille,President,,Stowe,,Gary Johnson. William,Libertarian,113,82048
-Orange,President,,Strafford,,Gary Johnson. William,Libertarian,24,82048
-Windham,President,,Stratton,,Gary Johnson. William,Libertarian,2,82048
-Rutland,President,,Sudbury,,Gary Johnson. William,Libertarian,12,82048
-Bennington,President,,Sunderland,Bennington 3,Gary Johnson. William,Libertarian,5,82048
-Bennington,President,,Sunderland,Bennington 4,Gary Johnson. William,Libertarian,7,82048
-Caledonia,President,,Sutton,,Gary Johnson. William,Libertarian,24,82048
-Franklin,President,,Swanton,,Gary Johnson. William,Libertarian,82,82048
-Orange,President,,Thetford,,Gary Johnson. William,Libertarian,45,82048
-Rutland,President,,Tinmouth,Rutland 2,Gary Johnson. William,Libertarian,2,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Gary Johnson. William,Libertarian,13,82048
-Orange,President,,Topsham,,Gary Johnson. William,Libertarian,19,82048
-Windham,President,,Townshend,,Gary Johnson. William,Libertarian,17,82048
-Orleans,President,,Troy,Orleans 2,Gary Johnson. William,Libertarian,6,82048
-Orleans,President,,Troy,Orleans-Lamoille,Gary Johnson. William,Libertarian,13,82048
-Orange,President,,Tunbridge,,Gary Johnson. William,Libertarian,21,82048
-Chittenden,President,,Underhill,,Gary Johnson. William,Libertarian,55,82048
-Addison,President,,Vergennes,,Gary Johnson. William,Libertarian,51,82048
-Windham,President,,Vernon,,Gary Johnson. William,Libertarian,50,82048
-Orange,President,,Vershire,,Gary Johnson. William,Libertarian,10,82048
-Essex,President,,Victory,,Gary Johnson. William,Libertarian,3,82048
-Washington,President,,Waitsfield,,Gary Johnson. William,Libertarian,29,82048
-Caledonia,President,,Walden,,Gary Johnson. William,Libertarian,22,82048
-Rutland,President,,Wallingford,,Gary Johnson. William,Libertarian,35,82048
-Addison,President,,Waltham,,Gary Johnson. William,Libertarian,14,82048
-Windham,President,,Wardsboro,,Gary Johnson. William,Libertarian,12,82048
-Washington,President,,Warren,,Gary Johnson. William,Libertarian,45,82048
-Orange,President,,Washington,,Gary Johnson. William,Libertarian,24,82048
-Washington,President,,Waterbury,,Gary Johnson. William,Libertarian,91,82048
-Caledonia,President,,Waterford,,Gary Johnson. William,Libertarian,37,82048
-Lamoille,President,,Waterville,,Gary Johnson. William,Libertarian,14,82048
-Windsor,President,,Weathersfield,,Gary Johnson. William,Libertarian,51,82048
-Rutland,President,,Wells,,Gary Johnson. William,Libertarian,17,82048
-Orange,President,,West Fairlee,,Gary Johnson. William,Libertarian,15,82048
-Rutland,President,,West Haven,,Gary Johnson. William,Libertarian,0,82048
-Rutland,President,,West Rutland,,Gary Johnson. William,Libertarian,33,82048
-Windsor,President,,West Windsor,,Gary Johnson. William,Libertarian,27,82048
-Orleans,President,,Westfield,,Gary Johnson. William,Libertarian,6,82048
-Chittenden,President,,Westford,,Gary Johnson. William,Libertarian,58,82048
-Windham,President,,Westminster,Windham 3,Gary Johnson. William,Libertarian,0,82048
-Windham,President,,Westminster,Windham 4,Gary Johnson. William,Libertarian,32,82048
-Orleans,President,,Westmore,,Gary Johnson. William,Libertarian,7,82048
-Windsor,President,,Weston,,Gary Johnson. William,Libertarian,8,82048
-Addison,President,,Weybridge,,Gary Johnson. William,Libertarian,18,82048
-Caledonia,President,,Wheelock,,Gary Johnson. William,Libertarian,13,82048
-Addison,President,,Whiting,,Gary Johnson. William,Libertarian,8,82048
-Windham,President,,Whitingham,Windham 6,Gary Johnson. William,Libertarian,22,82048
-Windham,President,,Whitingham,Windham-Bennington,Gary Johnson. William,Libertarian,0,82048
-Orange,President,,Williamstown,,Gary Johnson. William,Libertarian,72,82048
-Chittenden,President,,Williston,,Gary Johnson. William,Libertarian,195,82048
-Windham,President,,Wilmington,,Gary Johnson. William,Libertarian,36,82048
-Windham,President,,Windham,,Gary Johnson. William,Libertarian,10,82048
-Windsor,President,,Windsor,,Gary Johnson. William,Libertarian,92,82048
-Bennington,President,,Winhall,,Gary Johnson. William,Libertarian,15,82048
-Chittenden,President,,Winooski,,Gary Johnson. William,Libertarian,78,82048
-Lamoille,President,,Wolcott,,Gary Johnson. William,Libertarian,24,82048
-Washington,President,,Woodbury,,Gary Johnson. William,Libertarian,18,82048
-Bennington,President,,Woodford,,Gary Johnson. William,Libertarian,6,82048
-Windsor,President,,Woodstock,,Gary Johnson. William,Libertarian,48,82048
-Washington,President,,Worcester,,Gary Johnson. William,Libertarian,19,82048
-Addison,President,,Addison,,Jill Stein. Ajuma Baraka,Green,8,82048
-Orleans,President,,Albany,,Jill Stein. Ajuma Baraka,Green,9,82048
-Grand Isle,President,,Alburgh,,Jill Stein. Ajuma Baraka,Green,8,82048
-Windsor,President,,Andover,,Jill Stein. Ajuma Baraka,Green,4,82048
-Bennington,President,,Arlington,,Jill Stein. Ajuma Baraka,Green,22,82048
-Windham,President,,Athens,,Jill Stein. Ajuma Baraka,Green,8,82048
-Franklin,President,,Bakersfield,,Jill Stein. Ajuma Baraka,Green,10,82048
-Windsor,President,,Baltimore,,Jill Stein. Ajuma Baraka,Green,2,82048
-Windsor,President,,Barnard,,Jill Stein. Ajuma Baraka,Green,11,82048
-Caledonia,President,,Barnet,,Jill Stein. Ajuma Baraka,Green,21,82048
-Washington,President,,Barre City,,Jill Stein. Ajuma Baraka,Green,66,82048
-Washington,President,,Barre Town,,Jill Stein. Ajuma Baraka,Green,55,82048
-Orleans,President,,Barton,,Jill Stein. Ajuma Baraka,Green,5,82048
-Lamoille,President,,Belvidere,,Jill Stein. Ajuma Baraka,Green,1,82048
-Bennington,President,,Bennington,Bennington 2-1,Jill Stein. Ajuma Baraka,Green,63,82048
-Bennington,President,,Bennington,Bennington 2-2,Jill Stein. Ajuma Baraka,Green,84,82048
-Rutland,President,,Benson,,Jill Stein. Ajuma Baraka,Green,10,82048
-Franklin,President,,Berkshire,,Jill Stein. Ajuma Baraka,Green,5,82048
-Washington,President,,Berlin,,Jill Stein. Ajuma Baraka,Green,31,82048
-Windsor,President,,Bethel,,Jill Stein. Ajuma Baraka,Green,36,82048
-Essex,President,,Bloomfield,,Jill Stein. Ajuma Baraka,Green,6,82048
-Chittenden,President,,Bolton,,Jill Stein. Ajuma Baraka,Green,8,82048
-Orange,President,,Bradford,,Jill Stein. Ajuma Baraka,Green,23,82048
-Orange,President,,Braintree,,Jill Stein. Ajuma Baraka,Green,9,82048
-Rutland,President,,Brandon,,Jill Stein. Ajuma Baraka,Green,33,82048
-Windham,President,,Brattleboro,Windham 2-1,Jill Stein. Ajuma Baraka,Green,51,82048
-Windham,President,,Brattleboro,Windham 2-2,Jill Stein. Ajuma Baraka,Green,110,82048
-Windham,President,,Brattleboro,Windham 2-3,Jill Stein. Ajuma Baraka,Green,75,82048
-Windsor,President,,Bridgewater,,Jill Stein. Ajuma Baraka,Green,13,82048
-Addison,President,,Bridport,,Jill Stein. Ajuma Baraka,Green,8,82048
-Essex,President,,Brighton,,Jill Stein. Ajuma Baraka,Green,8,82048
-Addison,President,,Bristol,,Jill Stein. Ajuma Baraka,Green,41,82048
-Orange,President,,Brookfield,,Jill Stein. Ajuma Baraka,Green,26,82048
-Windham,President,,Brookline,,Jill Stein. Ajuma Baraka,Green,6,82048
-Orleans,President,,Brownington,,Jill Stein. Ajuma Baraka,Green,2,82048
-Essex,President,,Brunswick,,Jill Stein. Ajuma Baraka,Green,0,82048
-Caledonia,President,,Burke,,Jill Stein. Ajuma Baraka,Green,13,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Jill Stein. Ajuma Baraka,Green,81,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Jill Stein. Ajuma Baraka,Green,90,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Jill Stein. Ajuma Baraka,Green,225,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Jill Stein. Ajuma Baraka,Green,96,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Jill Stein. Ajuma Baraka,Green,164,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Jill Stein. Ajuma Baraka,Green,29,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Jill Stein. Ajuma Baraka,Green,4,82048
-Washington,President,,Cabot,,Jill Stein. Ajuma Baraka,Green,32,82048
-Washington,President,,Calais,,Jill Stein. Ajuma Baraka,Green,42,82048
-Lamoille,President,,Cambridge,,Jill Stein. Ajuma Baraka,Green,41,82048
-Essex,President,,Canaan,,Jill Stein. Ajuma Baraka,Green,2,82048
-Rutland,President,,Castleton,,Jill Stein. Ajuma Baraka,Green,22,82048
-Windsor,President,,Cavendish,,Jill Stein. Ajuma Baraka,Green,19,82048
-Orleans,President,,Charleston,,Jill Stein. Ajuma Baraka,Green,13,82048
-Chittenden,President,,Charlotte,,Jill Stein. Ajuma Baraka,Green,54,82048
-Orange,President,,Chelsea,,Jill Stein. Ajuma Baraka,Green,12,82048
-Windsor,President,,Chester,,Jill Stein. Ajuma Baraka,Green,34,82048
-Rutland,President,,Chittenden,,Jill Stein. Ajuma Baraka,Green,11,82048
-Rutland,President,,Clarendon,,Jill Stein. Ajuma Baraka,Green,11,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Jill Stein. Ajuma Baraka,Green,56,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Jill Stein. Ajuma Baraka,Green,64,82048
-Essex,President,,Concord,,Jill Stein. Ajuma Baraka,Green,3,82048
-Orange,President,,Corinth,,Jill Stein. Ajuma Baraka,Green,14,82048
-Addison,President,,Cornwall,,Jill Stein. Ajuma Baraka,Green,14,82048
-Orleans,President,,Coventry,,Jill Stein. Ajuma Baraka,Green,5,82048
-Orleans,President,,Craftsbury,,Jill Stein. Ajuma Baraka,Green,25,82048
-Rutland,President,,Danby,,Jill Stein. Ajuma Baraka,Green,15,82048
-Caledonia,President,,Danville,,Jill Stein. Ajuma Baraka,Green,22,82048
-Orleans,President,,Derby,,Jill Stein. Ajuma Baraka,Green,36,82048
-Bennington,President,,Dorset,,Jill Stein. Ajuma Baraka,Green,18,82048
-Windham,President,,Dover,,Jill Stein. Ajuma Baraka,Green,14,82048
-Windham,President,,Dummerston,,Jill Stein. Ajuma Baraka,Green,27,82048
-Washington,President,,Duxbury,,Jill Stein. Ajuma Baraka,Green,18,82048
-Essex,President,,East Haven,,Jill Stein. Ajuma Baraka,Green,6,82048
-Washington,President,,East Montpelier,,Jill Stein. Ajuma Baraka,Green,62,82048
-Lamoille,President,,Eden,,Jill Stein. Ajuma Baraka,Green,18,82048
-Lamoille,President,,Elmore,,Jill Stein. Ajuma Baraka,Green,16,82048
-Franklin,President,,Enosburgh,,Jill Stein. Ajuma Baraka,Green,22,82048
-Chittenden,President,,Essex,Chittenden 8-1,Jill Stein. Ajuma Baraka,Green,54,82048
-Chittenden,President,,Essex,Chittenden 8-2,Jill Stein. Ajuma Baraka,Green,84,82048
-Chittenden,President,,Essex,Chittenden 8-3,Jill Stein. Ajuma Baraka,Green,17,82048
-Rutland,President,,Fair Haven,,Jill Stein. Ajuma Baraka,Green,17,82048
-Franklin,President,,Fairfax,,Jill Stein. Ajuma Baraka,Green,42,82048
-Franklin,President,,Fairfield,,Jill Stein. Ajuma Baraka,Green,12,82048
-Orange,President,,Fairlee,,Jill Stein. Ajuma Baraka,Green,11,82048
-Washington,President,,Fayston,,Jill Stein. Ajuma Baraka,Green,23,82048
-Addison,President,,Ferrisburgh,,Jill Stein. Ajuma Baraka,Green,21,82048
-Franklin,President,,Fletcher,,Jill Stein. Ajuma Baraka,Green,23,82048
-Franklin,President,,Franklin,,Jill Stein. Ajuma Baraka,Green,4,82048
-Franklin,President,,Georgia,,Jill Stein. Ajuma Baraka,Green,38,82048
-Orleans,President,,Glover,,Jill Stein. Ajuma Baraka,Green,15,82048
-Addison,President,,Goshen,,Jill Stein. Ajuma Baraka,Green,3,82048
-Windham,President,,Grafton,,Jill Stein. Ajuma Baraka,Green,6,82048
-Essex,President,,Granby,,Jill Stein. Ajuma Baraka,Green,3,82048
-Grand Isle,President,,Grand Isle,,Jill Stein. Ajuma Baraka,Green,13,82048
-Addison,President,,Granville,,Jill Stein. Ajuma Baraka,Green,6,82048
-Orleans,President,,Greensboro,,Jill Stein. Ajuma Baraka,Green,11,82048
-Caledonia,President,,Groton,,Jill Stein. Ajuma Baraka,Green,16,82048
-Essex,President,,Guildhall,,Jill Stein. Ajuma Baraka,Green,3,82048
-Windham,President,,Guilford,,Jill Stein. Ajuma Baraka,Green,44,82048
-Windham,President,,Halifax,,Jill Stein. Ajuma Baraka,Green,12,82048
-Addison,President,,Hancock,,Jill Stein. Ajuma Baraka,Green,4,82048
-Caledonia,President,,Hardwick,,Jill Stein. Ajuma Baraka,Green,49,82048
-Windsor,President,,Hartford,Windsor 4-1,Jill Stein. Ajuma Baraka,Green,20,82048
-Windsor,President,,Hartford,Windsor 4-2,Jill Stein. Ajuma Baraka,Green,73,82048
-Windsor,President,,Hartland,,Jill Stein. Ajuma Baraka,Green,38,82048
-Franklin,President,,Highgate,,Jill Stein. Ajuma Baraka,Green,11,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Jill Stein. Ajuma Baraka,Green,0,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Jill Stein. Ajuma Baraka,Green,57,82048
-Orleans,President,,Holland,,Jill Stein. Ajuma Baraka,Green,2,82048
-Rutland,President,,Hubbardton,,Jill Stein. Ajuma Baraka,Green,6,82048
-Chittenden,President,,Huntington,,Jill Stein. Ajuma Baraka,Green,35,82048
-Lamoille,President,,Hyde Park,,Jill Stein. Ajuma Baraka,Green,37,82048
-Rutland,President,,Ira,,Jill Stein. Ajuma Baraka,Green,19,82048
-Orleans,President,,Irasburg,,Jill Stein. Ajuma Baraka,Green,2,82048
-Grand Isle,President,,Isle La Motte,,Jill Stein. Ajuma Baraka,Green,5,82048
-Windham,President,,Jamaica,,Jill Stein. Ajuma Baraka,Green,11,82048
-Orleans,President,,Jay,,Jill Stein. Ajuma Baraka,Green,3,82048
-Chittenden,President,,Jericho,,Jill Stein. Ajuma Baraka,Green,54,82048
-Lamoille,President,,Johnson,,Jill Stein. Ajuma Baraka,Green,48,82048
-Rutland,President,,Killington,,Jill Stein. Ajuma Baraka,Green,10,82048
-Caledonia,President,,Kirby,,Jill Stein. Ajuma Baraka,Green,8,82048
-Bennington,President,,Landgrove,,Jill Stein. Ajuma Baraka,Green,1,82048
-Addison,President,,Leicester,,Jill Stein. Ajuma Baraka,Green,5,82048
-Essex,President,,Lemington,,Jill Stein. Ajuma Baraka,Green,1,82048
-Addison,President,,Lincoln,,Jill Stein. Ajuma Baraka,Green,27,82048
-Windham,President,,Londonderry,,Jill Stein. Ajuma Baraka,Green,27,82048
-Orleans,President,,Lowell,,Jill Stein. Ajuma Baraka,Green,4,82048
-Windsor,President,,Ludlow,,Jill Stein. Ajuma Baraka,Green,23,82048
-Essex,President,,Lunenburg,,Jill Stein. Ajuma Baraka,Green,9,82048
-Caledonia,President,,Lyndon,,Jill Stein. Ajuma Baraka,Green,43,82048
-Essex,President,,Maidstone,,Jill Stein. Ajuma Baraka,Green,1,82048
-Bennington,President,,Manchester,,Jill Stein. Ajuma Baraka,Green,33,82048
-Windham,President,,Marlboro,,Jill Stein. Ajuma Baraka,Green,21,82048
-Washington,President,,Marshfield,,Jill Stein. Ajuma Baraka,Green,51,82048
-Rutland,President,,Mendon,,Jill Stein. Ajuma Baraka,Green,10,82048
-Addison,President,,Middlebury,,Jill Stein. Ajuma Baraka,Green,71,82048
-Washington,President,,Middlesex,,Jill Stein. Ajuma Baraka,Green,47,82048
-Rutland,President,,Middletown Springs,,Jill Stein. Ajuma Baraka,Green,18,82048
-Chittenden,President,,Milton,Chittenden 10,Jill Stein. Ajuma Baraka,Green,63,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Jill Stein. Ajuma Baraka,Green,7,82048
-Addison,President,,Monkton,,Jill Stein. Ajuma Baraka,Green,16,82048
-Franklin,President,,Montgomery,,Jill Stein. Ajuma Baraka,Green,19,82048
-Washington,President,,Montpelier,,Jill Stein. Ajuma Baraka,Green,208,82048
-Washington,President,,Moretown,,Jill Stein. Ajuma Baraka,Green,22,82048
-Orleans,President,,Morgan,,Jill Stein. Ajuma Baraka,Green,2,82048
-Lamoille,President,,Morristown,,Jill Stein. Ajuma Baraka,Green,89,82048
-Rutland,President,,Mount Holly,,Jill Stein. Ajuma Baraka,Green,15,82048
-Rutland,President,,Mount Tabor,,Jill Stein. Ajuma Baraka,Green,0,82048
-Addison,President,,New Haven,,Jill Stein. Ajuma Baraka,Green,21,82048
-Caledonia,President,,Newark,,Jill Stein. Ajuma Baraka,Green,13,82048
-Orange,President,,Newbury,,Jill Stein. Ajuma Baraka,Green,21,82048
-Windham,President,,Newfane,,Jill Stein. Ajuma Baraka,Green,42,82048
-Orleans,President,,Newport City,,Jill Stein. Ajuma Baraka,Green,19,82048
-Orleans,President,,Newport Town,,Jill Stein. Ajuma Baraka,Green,16,82048
-Grand Isle,President,,North Hero,,Jill Stein. Ajuma Baraka,Green,6,82048
-Washington,President,,Northfield,,Jill Stein. Ajuma Baraka,Green,49,82048
-Essex,President,,Norton,,Jill Stein. Ajuma Baraka,Green,0,82048
-Windsor,President,,Norwich,,Jill Stein. Ajuma Baraka,Green,33,82048
-Orange,President,,Orange,,Jill Stein. Ajuma Baraka,Green,17,82048
-Addison,President,,Orwell,,Jill Stein. Ajuma Baraka,Green,16,82048
-Addison,President,,Panton,,Jill Stein. Ajuma Baraka,Green,6,82048
-Rutland,President,,Pawlet,,Jill Stein. Ajuma Baraka,Green,9,82048
-Caledonia,President,,Peacham,,Jill Stein. Ajuma Baraka,Green,11,82048
-Bennington,President,,Peru,,Jill Stein. Ajuma Baraka,Green,2,82048
-Rutland,President,,Pittsfield,,Jill Stein. Ajuma Baraka,Green,5,82048
-Rutland,President,,Pittsford,,Jill Stein. Ajuma Baraka,Green,19,82048
-Washington,President,,Plainfield,,Jill Stein. Ajuma Baraka,Green,42,82048
-Windsor,President,,Plymouth,,Jill Stein. Ajuma Baraka,Green,9,82048
-Windsor,President,,Pomfret,,Jill Stein. Ajuma Baraka,Green,7,82048
-Rutland,President,,Poultney,,Jill Stein. Ajuma Baraka,Green,37,82048
-Bennington,President,,Pownal,,Jill Stein. Ajuma Baraka,Green,29,82048
-Rutland,President,,Proctor,,Jill Stein. Ajuma Baraka,Green,12,82048
-Windham,President,,Putney,,Jill Stein. Ajuma Baraka,Green,40,82048
-Orange,President,,Randolph,,Jill Stein. Ajuma Baraka,Green,67,82048
-Windsor,President,,Reading,,Jill Stein. Ajuma Baraka,Green,7,82048
-Bennington,President,,Readsboro,,Jill Stein. Ajuma Baraka,Green,7,82048
-Franklin,President,,Richford,,Jill Stein. Ajuma Baraka,Green,15,82048
-Chittenden,President,,Richmond,,Jill Stein. Ajuma Baraka,Green,49,82048
-Addison,President,,Ripton,,Jill Stein. Ajuma Baraka,Green,13,82048
-Windsor,President,,Rochester,,Jill Stein. Ajuma Baraka,Green,17,82048
-Windham,President,,Rockingham,,Jill Stein. Ajuma Baraka,Green,46,82048
-Washington,President,,Roxbury,,Jill Stein. Ajuma Baraka,Green,14,82048
-Windsor,President,,Royalton,,Jill Stein. Ajuma Baraka,Green,31,82048
-Bennington,President,,Rupert,,Jill Stein. Ajuma Baraka,Green,6,82048
-Rutland,President,,Rutland City,Rutland 5-1,Jill Stein. Ajuma Baraka,Green,27,82048
-Rutland,President,,Rutland City,Rutland 5-2,Jill Stein. Ajuma Baraka,Green,34,82048
-Rutland,President,,Rutland City,Rutland 5-3,Jill Stein. Ajuma Baraka,Green,24,82048
-Rutland,President,,Rutland City,Rutland 5-4,Jill Stein. Ajuma Baraka,Green,24,82048
-Rutland,President,,Rutland Town,,Jill Stein. Ajuma Baraka,Green,19,82048
-Caledonia,President,,Ryegate,,Jill Stein. Ajuma Baraka,Green,12,82048
-Addison,President,,Salisbury,,Jill Stein. Ajuma Baraka,Green,9,82048
-Bennington,President,,Sandgate,,Jill Stein. Ajuma Baraka,Green,7,82048
-Bennington,President,,Searsburg,,Jill Stein. Ajuma Baraka,Green,0,82048
-Bennington,President,,Shaftsbury,,Jill Stein. Ajuma Baraka,Green,26,82048
-Windsor,President,,Sharon,,Jill Stein. Ajuma Baraka,Green,25,82048
-Caledonia,President,,Sheffield,,Jill Stein. Ajuma Baraka,Green,6,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Jill Stein. Ajuma Baraka,Green,48,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Jill Stein. Ajuma Baraka,Green,31,82048
-Franklin,President,,Sheldon,,Jill Stein. Ajuma Baraka,Green,11,82048
-Addison,President,,Shoreham,,Jill Stein. Ajuma Baraka,Green,13,82048
-Rutland,President,,Shrewsbury,,Jill Stein. Ajuma Baraka,Green,9,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Jill Stein. Ajuma Baraka,Green,39,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Jill Stein. Ajuma Baraka,Green,35,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Jill Stein. Ajuma Baraka,Green,61,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Jill Stein. Ajuma Baraka,Green,61,82048
-Grand Isle,President,,South Hero,,Jill Stein. Ajuma Baraka,Green,18,82048
-Windsor,President,,Springfield,Windsor 3-1,Jill Stein. Ajuma Baraka,Green,3,82048
-Windsor,President,,Springfield,Windsor 3-2,Jill Stein. Ajuma Baraka,Green,82,82048
-Franklin,President,,Saint Albans City,,Jill Stein. Ajuma Baraka,Green,43,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Jill Stein. Ajuma Baraka,Green,9,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Jill Stein. Ajuma Baraka,Green,23,82048
-Chittenden,President,,Saint George,,Jill Stein. Ajuma Baraka,Green,6,82048
-Caledonia,President,,Saint Johnsbury,,Jill Stein. Ajuma Baraka,Green,64,82048
-Bennington,President,,Stamford,,Jill Stein. Ajuma Baraka,Green,6,82048
-Caledonia,President,,Stannard,,Jill Stein. Ajuma Baraka,Green,1,82048
-Addison,President,,Starksboro,,Jill Stein. Ajuma Baraka,Green,24,82048
-Windsor,President,,Stockbridge,,Jill Stein. Ajuma Baraka,Green,13,82048
-Lamoille,President,,Stowe,,Jill Stein. Ajuma Baraka,Green,39,82048
-Orange,President,,Strafford,,Jill Stein. Ajuma Baraka,Green,30,82048
-Windham,President,,Stratton,,Jill Stein. Ajuma Baraka,Green,0,82048
-Rutland,President,,Sudbury,,Jill Stein. Ajuma Baraka,Green,3,82048
-Bennington,President,,Sunderland,Bennington 3,Jill Stein. Ajuma Baraka,Green,3,82048
-Bennington,President,,Sunderland,Bennington 4,Jill Stein. Ajuma Baraka,Green,3,82048
-Caledonia,President,,Sutton,,Jill Stein. Ajuma Baraka,Green,11,82048
-Franklin,President,,Swanton,,Jill Stein. Ajuma Baraka,Green,33,82048
-Orange,President,,Thetford,,Jill Stein. Ajuma Baraka,Green,34,82048
-Rutland,President,,Tinmouth,Rutland 2,Jill Stein. Ajuma Baraka,Green,1,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Jill Stein. Ajuma Baraka,Green,2,82048
-Orange,President,,Topsham,,Jill Stein. Ajuma Baraka,Green,8,82048
-Windham,President,,Townshend,,Jill Stein. Ajuma Baraka,Green,10,82048
-Orleans,President,,Troy,Orleans 2,Jill Stein. Ajuma Baraka,Green,3,82048
-Orleans,President,,Troy,Orleans-Lamoille,Jill Stein. Ajuma Baraka,Green,7,82048
-Orange,President,,Tunbridge,,Jill Stein. Ajuma Baraka,Green,22,82048
-Chittenden,President,,Underhill,,Jill Stein. Ajuma Baraka,Green,26,82048
-Addison,President,,Vergennes,,Jill Stein. Ajuma Baraka,Green,23,82048
-Windham,President,,Vernon,,Jill Stein. Ajuma Baraka,Green,11,82048
-Orange,President,,Vershire,,Jill Stein. Ajuma Baraka,Green,18,82048
-Essex,President,,Victory,,Jill Stein. Ajuma Baraka,Green,1,82048
-Washington,President,,Waitsfield,,Jill Stein. Ajuma Baraka,Green,35,82048
-Caledonia,President,,Walden,,Jill Stein. Ajuma Baraka,Green,25,82048
-Rutland,President,,Wallingford,,Jill Stein. Ajuma Baraka,Green,22,82048
-Addison,President,,Waltham,,Jill Stein. Ajuma Baraka,Green,2,82048
-Windham,President,,Wardsboro,,Jill Stein. Ajuma Baraka,Green,11,82048
-Washington,President,,Warren,,Jill Stein. Ajuma Baraka,Green,25,82048
-Orange,President,,Washington,,Jill Stein. Ajuma Baraka,Green,11,82048
-Washington,President,,Waterbury,,Jill Stein. Ajuma Baraka,Green,44,82048
-Caledonia,President,,Waterford,,Jill Stein. Ajuma Baraka,Green,5,82048
-Lamoille,President,,Waterville,,Jill Stein. Ajuma Baraka,Green,10,82048
-Windsor,President,,Weathersfield,,Jill Stein. Ajuma Baraka,Green,26,82048
-Rutland,President,,Wells,,Jill Stein. Ajuma Baraka,Green,6,82048
-Orange,President,,West Fairlee,,Jill Stein. Ajuma Baraka,Green,2,82048
-Rutland,President,,West Haven,,Jill Stein. Ajuma Baraka,Green,7,82048
-Rutland,President,,West Rutland,,Jill Stein. Ajuma Baraka,Green,10,82048
-Windsor,President,,West Windsor,,Jill Stein. Ajuma Baraka,Green,6,82048
-Orleans,President,,Westfield,,Jill Stein. Ajuma Baraka,Green,11,82048
-Chittenden,President,,Westford,,Jill Stein. Ajuma Baraka,Green,22,82048
-Windham,President,,Westminster,Windham 3,Jill Stein. Ajuma Baraka,Green,4,82048
-Windham,President,,Westminster,Windham 4,Jill Stein. Ajuma Baraka,Green,57,82048
-Orleans,President,,Westmore,,Jill Stein. Ajuma Baraka,Green,4,82048
-Windsor,President,,Weston,,Jill Stein. Ajuma Baraka,Green,5,82048
-Addison,President,,Weybridge,,Jill Stein. Ajuma Baraka,Green,8,82048
-Caledonia,President,,Wheelock,,Jill Stein. Ajuma Baraka,Green,13,82048
-Addison,President,,Whiting,,Jill Stein. Ajuma Baraka,Green,2,82048
-Windham,President,,Whitingham,Windham 6,Jill Stein. Ajuma Baraka,Green,10,82048
-Windham,President,,Whitingham,Windham-Bennington,Jill Stein. Ajuma Baraka,Green,0,82048
-Orange,President,,Williamstown,,Jill Stein. Ajuma Baraka,Green,25,82048
-Chittenden,President,,Williston,,Jill Stein. Ajuma Baraka,Green,69,82048
-Windham,President,,Wilmington,,Jill Stein. Ajuma Baraka,Green,26,82048
-Windham,President,,Windham,,Jill Stein. Ajuma Baraka,Green,8,82048
-Windsor,President,,Windsor,,Jill Stein. Ajuma Baraka,Green,44,82048
-Bennington,President,,Winhall,,Jill Stein. Ajuma Baraka,Green,7,82048
-Chittenden,President,,Winooski,,Jill Stein. Ajuma Baraka,Green,107,82048
-Lamoille,President,,Wolcott,,Jill Stein. Ajuma Baraka,Green,27,82048
-Washington,President,,Woodbury,,Jill Stein. Ajuma Baraka,Green,18,82048
-Bennington,President,,Woodford,,Jill Stein. Ajuma Baraka,Green,1,82048
-Windsor,President,,Woodstock,,Jill Stein. Ajuma Baraka,Green,31,82048
-Washington,President,,Worcester,,Jill Stein. Ajuma Baraka,Green,27,82048
-Addison,President,,Addison,,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Albany,,Rocky De La Fuente. Michael,Independent,3,82048
-Grand Isle,President,,Alburgh,,Rocky De La Fuente. Michael,Independent,5,82048
-Windsor,President,,Andover,,Rocky De La Fuente. Michael,Independent,1,82048
-Bennington,President,,Arlington,,Rocky De La Fuente. Michael,Independent,4,82048
-Windham,President,,Athens,,Rocky De La Fuente. Michael,Independent,1,82048
-Franklin,President,,Bakersfield,,Rocky De La Fuente. Michael,Independent,4,82048
-Windsor,President,,Baltimore,,Rocky De La Fuente. Michael,Independent,2,82048
-Windsor,President,,Barnard,,Rocky De La Fuente. Michael,Independent,2,82048
-Caledonia,President,,Barnet,,Rocky De La Fuente. Michael,Independent,5,82048
-Washington,President,,Barre City,,Rocky De La Fuente. Michael,Independent,21,82048
-Washington,President,,Barre Town,,Rocky De La Fuente. Michael,Independent,22,82048
-Orleans,President,,Barton,,Rocky De La Fuente. Michael,Independent,4,82048
-Lamoille,President,,Belvidere,,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Bennington,Bennington 2-1,Rocky De La Fuente. Michael,Independent,13,82048
-Bennington,President,,Bennington,Bennington 2-2,Rocky De La Fuente. Michael,Independent,9,82048
-Rutland,President,,Benson,,Rocky De La Fuente. Michael,Independent,3,82048
-Franklin,President,,Berkshire,,Rocky De La Fuente. Michael,Independent,8,82048
-Washington,President,,Berlin,,Rocky De La Fuente. Michael,Independent,7,82048
-Windsor,President,,Bethel,,Rocky De La Fuente. Michael,Independent,2,82048
-Essex,President,,Bloomfield,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Bolton,,Rocky De La Fuente. Michael,Independent,2,82048
-Orange,President,,Bradford,,Rocky De La Fuente. Michael,Independent,2,82048
-Orange,President,,Braintree,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Brandon,,Rocky De La Fuente. Michael,Independent,8,82048
-Windham,President,,Brattleboro,Windham 2-1,Rocky De La Fuente. Michael,Independent,5,82048
-Windham,President,,Brattleboro,Windham 2-2,Rocky De La Fuente. Michael,Independent,3,82048
-Windham,President,,Brattleboro,Windham 2-3,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Bridgewater,,Rocky De La Fuente. Michael,Independent,16,82048
-Addison,President,,Bridport,,Rocky De La Fuente. Michael,Independent,3,82048
-Essex,President,,Brighton,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Bristol,,Rocky De La Fuente. Michael,Independent,9,82048
-Orange,President,,Brookfield,,Rocky De La Fuente. Michael,Independent,10,82048
-Windham,President,,Brookline,,Rocky De La Fuente. Michael,Independent,5,82048
-Orleans,President,,Brownington,,Rocky De La Fuente. Michael,Independent,1,82048
-Essex,President,,Brunswick,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Burke,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Rocky De La Fuente. Michael,Independent,9,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Rocky De La Fuente. Michael,Independent,5,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Rocky De La Fuente. Michael,Independent,7,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Rocky De La Fuente. Michael,Independent,5,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Rocky De La Fuente. Michael,Independent,2,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Rocky De La Fuente. Michael,Independent,0,82048
-Washington,President,,Cabot,,Rocky De La Fuente. Michael,Independent,4,82048
-Washington,President,,Calais,,Rocky De La Fuente. Michael,Independent,3,82048
-Lamoille,President,,Cambridge,,Rocky De La Fuente. Michael,Independent,6,82048
-Essex,President,,Canaan,,Rocky De La Fuente. Michael,Independent,3,82048
-Rutland,President,,Castleton,,Rocky De La Fuente. Michael,Independent,6,82048
-Windsor,President,,Cavendish,,Rocky De La Fuente. Michael,Independent,5,82048
-Orleans,President,,Charleston,,Rocky De La Fuente. Michael,Independent,2,82048
-Chittenden,President,,Charlotte,,Rocky De La Fuente. Michael,Independent,6,82048
-Orange,President,,Chelsea,,Rocky De La Fuente. Michael,Independent,4,82048
-Windsor,President,,Chester,,Rocky De La Fuente. Michael,Independent,3,82048
-Rutland,President,,Chittenden,,Rocky De La Fuente. Michael,Independent,2,82048
-Rutland,President,,Clarendon,,Rocky De La Fuente. Michael,Independent,2,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Rocky De La Fuente. Michael,Independent,9,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Rocky De La Fuente. Michael,Independent,13,82048
-Essex,President,,Concord,,Rocky De La Fuente. Michael,Independent,2,82048
-Orange,President,,Corinth,,Rocky De La Fuente. Michael,Independent,3,82048
-Addison,President,,Cornwall,,Rocky De La Fuente. Michael,Independent,3,82048
-Orleans,President,,Coventry,,Rocky De La Fuente. Michael,Independent,2,82048
-Orleans,President,,Craftsbury,,Rocky De La Fuente. Michael,Independent,3,82048
-Rutland,President,,Danby,,Rocky De La Fuente. Michael,Independent,4,82048
-Caledonia,President,,Danville,,Rocky De La Fuente. Michael,Independent,4,82048
-Orleans,President,,Derby,,Rocky De La Fuente. Michael,Independent,3,82048
-Bennington,President,,Dorset,,Rocky De La Fuente. Michael,Independent,4,82048
-Windham,President,,Dover,,Rocky De La Fuente. Michael,Independent,3,82048
-Windham,President,,Dummerston,,Rocky De La Fuente. Michael,Independent,2,82048
-Washington,President,,Duxbury,,Rocky De La Fuente. Michael,Independent,6,82048
-Essex,President,,East Haven,,Rocky De La Fuente. Michael,Independent,2,82048
-Washington,President,,East Montpelier,,Rocky De La Fuente. Michael,Independent,2,82048
-Lamoille,President,,Eden,,Rocky De La Fuente. Michael,Independent,2,82048
-Lamoille,President,,Elmore,,Rocky De La Fuente. Michael,Independent,0,82048
-Franklin,President,,Enosburgh,,Rocky De La Fuente. Michael,Independent,8,82048
-Chittenden,President,,Essex,Chittenden 8-1,Rocky De La Fuente. Michael,Independent,16,82048
-Chittenden,President,,Essex,Chittenden 8-2,Rocky De La Fuente. Michael,Independent,14,82048
-Chittenden,President,,Essex,Chittenden 8-3,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Fair Haven,,Rocky De La Fuente. Michael,Independent,5,82048
-Franklin,President,,Fairfax,,Rocky De La Fuente. Michael,Independent,6,82048
-Franklin,President,,Fairfield,,Rocky De La Fuente. Michael,Independent,0,82048
-Orange,President,,Fairlee,,Rocky De La Fuente. Michael,Independent,5,82048
-Washington,President,,Fayston,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Ferrisburgh,,Rocky De La Fuente. Michael,Independent,3,82048
-Franklin,President,,Fletcher,,Rocky De La Fuente. Michael,Independent,3,82048
-Franklin,President,,Franklin,,Rocky De La Fuente. Michael,Independent,4,82048
-Franklin,President,,Georgia,,Rocky De La Fuente. Michael,Independent,8,82048
-Orleans,President,,Glover,,Rocky De La Fuente. Michael,Independent,2,82048
-Addison,President,,Goshen,,Rocky De La Fuente. Michael,Independent,0,82048
-Windham,President,,Grafton,,Rocky De La Fuente. Michael,Independent,1,82048
-Essex,President,,Granby,,Rocky De La Fuente. Michael,Independent,0,82048
-Grand Isle,President,,Grand Isle,,Rocky De La Fuente. Michael,Independent,6,82048
-Addison,President,,Granville,,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Greensboro,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Groton,,Rocky De La Fuente. Michael,Independent,4,82048
-Essex,President,,Guildhall,,Rocky De La Fuente. Michael,Independent,0,82048
-Windham,President,,Guilford,,Rocky De La Fuente. Michael,Independent,1,82048
-Windham,President,,Halifax,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Hancock,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Hardwick,,Rocky De La Fuente. Michael,Independent,5,82048
-Windsor,President,,Hartford,Windsor 4-1,Rocky De La Fuente. Michael,Independent,2,82048
-Windsor,President,,Hartford,Windsor 4-2,Rocky De La Fuente. Michael,Independent,20,82048
-Windsor,President,,Hartland,,Rocky De La Fuente. Michael,Independent,3,82048
-Franklin,President,,Highgate,,Rocky De La Fuente. Michael,Independent,7,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Rocky De La Fuente. Michael,Independent,0,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Holland,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Hubbardton,,Rocky De La Fuente. Michael,Independent,3,82048
-Chittenden,President,,Huntington,,Rocky De La Fuente. Michael,Independent,10,82048
-Lamoille,President,,Hyde Park,,Rocky De La Fuente. Michael,Independent,5,82048
-Rutland,President,,Ira,,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Irasburg,,Rocky De La Fuente. Michael,Independent,0,82048
-Grand Isle,President,,Isle La Motte,,Rocky De La Fuente. Michael,Independent,0,82048
-Windham,President,,Jamaica,,Rocky De La Fuente. Michael,Independent,2,82048
-Orleans,President,,Jay,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Jericho,,Rocky De La Fuente. Michael,Independent,9,82048
-Lamoille,President,,Johnson,,Rocky De La Fuente. Michael,Independent,2,82048
-Rutland,President,,Killington,,Rocky De La Fuente. Michael,Independent,2,82048
-Caledonia,President,,Kirby,,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Landgrove,,Rocky De La Fuente. Michael,Independent,0,82048
-Addison,President,,Leicester,,Rocky De La Fuente. Michael,Independent,3,82048
-Essex,President,,Lemington,,Rocky De La Fuente. Michael,Independent,0,82048
-Addison,President,,Lincoln,,Rocky De La Fuente. Michael,Independent,3,82048
-Windham,President,,Londonderry,,Rocky De La Fuente. Michael,Independent,3,82048
-Orleans,President,,Lowell,,Rocky De La Fuente. Michael,Independent,3,82048
-Windsor,President,,Ludlow,,Rocky De La Fuente. Michael,Independent,7,82048
-Essex,President,,Lunenburg,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Lyndon,,Rocky De La Fuente. Michael,Independent,8,82048
-Essex,President,,Maidstone,,Rocky De La Fuente. Michael,Independent,1,82048
-Bennington,President,,Manchester,,Rocky De La Fuente. Michael,Independent,10,82048
-Windham,President,,Marlboro,,Rocky De La Fuente. Michael,Independent,1,82048
-Washington,President,,Marshfield,,Rocky De La Fuente. Michael,Independent,4,82048
-Rutland,President,,Mendon,,Rocky De La Fuente. Michael,Independent,3,82048
-Addison,President,,Middlebury,,Rocky De La Fuente. Michael,Independent,11,82048
-Washington,President,,Middlesex,,Rocky De La Fuente. Michael,Independent,5,82048
-Rutland,President,,Middletown Springs,,Rocky De La Fuente. Michael,Independent,7,82048
-Chittenden,President,,Milton,Chittenden 10,Rocky De La Fuente. Michael,Independent,17,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Rocky De La Fuente. Michael,Independent,2,82048
-Addison,President,,Monkton,,Rocky De La Fuente. Michael,Independent,2,82048
-Franklin,President,,Montgomery,,Rocky De La Fuente. Michael,Independent,3,82048
-Washington,President,,Montpelier,,Rocky De La Fuente. Michael,Independent,7,82048
-Washington,President,,Moretown,,Rocky De La Fuente. Michael,Independent,3,82048
-Orleans,President,,Morgan,,Rocky De La Fuente. Michael,Independent,1,82048
-Lamoille,President,,Morristown,,Rocky De La Fuente. Michael,Independent,9,82048
-Rutland,President,,Mount Holly,,Rocky De La Fuente. Michael,Independent,4,82048
-Rutland,President,,Mount Tabor,,Rocky De La Fuente. Michael,Independent,0,82048
-Addison,President,,New Haven,,Rocky De La Fuente. Michael,Independent,5,82048
-Caledonia,President,,Newark,,Rocky De La Fuente. Michael,Independent,0,82048
-Orange,President,,Newbury,,Rocky De La Fuente. Michael,Independent,4,82048
-Windham,President,,Newfane,,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Newport City,,Rocky De La Fuente. Michael,Independent,4,82048
-Orleans,President,,Newport Town,,Rocky De La Fuente. Michael,Independent,3,82048
-Grand Isle,President,,North Hero,,Rocky De La Fuente. Michael,Independent,0,82048
-Washington,President,,Northfield,,Rocky De La Fuente. Michael,Independent,10,82048
-Essex,President,,Norton,,Rocky De La Fuente. Michael,Independent,0,82048
-Windsor,President,,Norwich,,Rocky De La Fuente. Michael,Independent,1,82048
-Orange,President,,Orange,,Rocky De La Fuente. Michael,Independent,3,82048
-Addison,President,,Orwell,,Rocky De La Fuente. Michael,Independent,5,82048
-Addison,President,,Panton,,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,Pawlet,,Rocky De La Fuente. Michael,Independent,3,82048
-Caledonia,President,,Peacham,,Rocky De La Fuente. Michael,Independent,3,82048
-Bennington,President,,Peru,,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,Pittsfield,,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,Pittsford,,Rocky De La Fuente. Michael,Independent,2,82048
-Washington,President,,Plainfield,,Rocky De La Fuente. Michael,Independent,3,82048
-Windsor,President,,Plymouth,,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Pomfret,,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,Poultney,,Rocky De La Fuente. Michael,Independent,6,82048
-Bennington,President,,Pownal,,Rocky De La Fuente. Michael,Independent,8,82048
-Rutland,President,,Proctor,,Rocky De La Fuente. Michael,Independent,8,82048
-Windham,President,,Putney,,Rocky De La Fuente. Michael,Independent,0,82048
-Orange,President,,Randolph,,Rocky De La Fuente. Michael,Independent,11,82048
-Windsor,President,,Reading,,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Readsboro,,Rocky De La Fuente. Michael,Independent,1,82048
-Franklin,President,,Richford,,Rocky De La Fuente. Michael,Independent,3,82048
-Chittenden,President,,Richmond,,Rocky De La Fuente. Michael,Independent,9,82048
-Addison,President,,Ripton,,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Rochester,,Rocky De La Fuente. Michael,Independent,1,82048
-Windham,President,,Rockingham,,Rocky De La Fuente. Michael,Independent,9,82048
-Washington,President,,Roxbury,,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Royalton,,Rocky De La Fuente. Michael,Independent,4,82048
-Bennington,President,,Rupert,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Rutland City,Rutland 5-1,Rocky De La Fuente. Michael,Independent,6,82048
-Rutland,President,,Rutland City,Rutland 5-2,Rocky De La Fuente. Michael,Independent,8,82048
-Rutland,President,,Rutland City,Rutland 5-3,Rocky De La Fuente. Michael,Independent,3,82048
-Rutland,President,,Rutland City,Rutland 5-4,Rocky De La Fuente. Michael,Independent,4,82048
-Rutland,President,,Rutland Town,,Rocky De La Fuente. Michael,Independent,8,82048
-Caledonia,President,,Ryegate,,Rocky De La Fuente. Michael,Independent,0,82048
-Addison,President,,Salisbury,,Rocky De La Fuente. Michael,Independent,3,82048
-Bennington,President,,Sandgate,,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Searsburg,,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Shaftsbury,,Rocky De La Fuente. Michael,Independent,7,82048
-Windsor,President,,Sharon,,Rocky De La Fuente. Michael,Independent,3,82048
-Caledonia,President,,Sheffield,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Rocky De La Fuente. Michael,Independent,4,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Rocky De La Fuente. Michael,Independent,4,82048
-Franklin,President,,Sheldon,,Rocky De La Fuente. Michael,Independent,2,82048
-Addison,President,,Shoreham,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Shrewsbury,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Rocky De La Fuente. Michael,Independent,3,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Rocky De La Fuente. Michael,Independent,4,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Rocky De La Fuente. Michael,Independent,5,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Rocky De La Fuente. Michael,Independent,7,82048
-Grand Isle,President,,South Hero,,Rocky De La Fuente. Michael,Independent,3,82048
-Windsor,President,,Springfield,Windsor 3-1,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Springfield,Windsor 3-2,Rocky De La Fuente. Michael,Independent,17,82048
-Franklin,President,,Saint Albans City,,Rocky De La Fuente. Michael,Independent,12,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Rocky De La Fuente. Michael,Independent,4,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Rocky De La Fuente. Michael,Independent,10,82048
-Chittenden,President,,Saint George,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Saint Johnsbury,,Rocky De La Fuente. Michael,Independent,16,82048
-Bennington,President,,Stamford,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Stannard,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Starksboro,,Rocky De La Fuente. Michael,Independent,3,82048
-Windsor,President,,Stockbridge,,Rocky De La Fuente. Michael,Independent,6,82048
-Lamoille,President,,Stowe,,Rocky De La Fuente. Michael,Independent,3,82048
-Orange,President,,Strafford,,Rocky De La Fuente. Michael,Independent,1,82048
-Windham,President,,Stratton,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,Sudbury,,Rocky De La Fuente. Michael,Independent,2,82048
-Bennington,President,,Sunderland,Bennington 3,Rocky De La Fuente. Michael,Independent,0,82048
-Bennington,President,,Sunderland,Bennington 4,Rocky De La Fuente. Michael,Independent,3,82048
-Caledonia,President,,Sutton,,Rocky De La Fuente. Michael,Independent,3,82048
-Franklin,President,,Swanton,,Rocky De La Fuente. Michael,Independent,6,82048
-Orange,President,,Thetford,,Rocky De La Fuente. Michael,Independent,2,82048
-Rutland,President,,Tinmouth,Rutland 2,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Rocky De La Fuente. Michael,Independent,0,82048
-Orange,President,,Topsham,,Rocky De La Fuente. Michael,Independent,7,82048
-Windham,President,,Townshend,,Rocky De La Fuente. Michael,Independent,3,82048
-Orleans,President,,Troy,Orleans 2,Rocky De La Fuente. Michael,Independent,1,82048
-Orleans,President,,Troy,Orleans-Lamoille,Rocky De La Fuente. Michael,Independent,3,82048
-Orange,President,,Tunbridge,,Rocky De La Fuente. Michael,Independent,2,82048
-Chittenden,President,,Underhill,,Rocky De La Fuente. Michael,Independent,2,82048
-Addison,President,,Vergennes,,Rocky De La Fuente. Michael,Independent,5,82048
-Windham,President,,Vernon,,Rocky De La Fuente. Michael,Independent,3,82048
-Orange,President,,Vershire,,Rocky De La Fuente. Michael,Independent,2,82048
-Essex,President,,Victory,,Rocky De La Fuente. Michael,Independent,0,82048
-Washington,President,,Waitsfield,,Rocky De La Fuente. Michael,Independent,6,82048
-Caledonia,President,,Walden,,Rocky De La Fuente. Michael,Independent,3,82048
-Rutland,President,,Wallingford,,Rocky De La Fuente. Michael,Independent,4,82048
-Addison,President,,Waltham,,Rocky De La Fuente. Michael,Independent,0,82048
-Windham,President,,Wardsboro,,Rocky De La Fuente. Michael,Independent,1,82048
-Washington,President,,Warren,,Rocky De La Fuente. Michael,Independent,4,82048
-Orange,President,,Washington,,Rocky De La Fuente. Michael,Independent,4,82048
-Washington,President,,Waterbury,,Rocky De La Fuente. Michael,Independent,16,82048
-Caledonia,President,,Waterford,,Rocky De La Fuente. Michael,Independent,1,82048
-Lamoille,President,,Waterville,,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Weathersfield,,Rocky De La Fuente. Michael,Independent,8,82048
-Rutland,President,,Wells,,Rocky De La Fuente. Michael,Independent,2,82048
-Orange,President,,West Fairlee,,Rocky De La Fuente. Michael,Independent,0,82048
-Rutland,President,,West Haven,,Rocky De La Fuente. Michael,Independent,1,82048
-Rutland,President,,West Rutland,,Rocky De La Fuente. Michael,Independent,4,82048
-Windsor,President,,West Windsor,,Rocky De La Fuente. Michael,Independent,2,82048
-Orleans,President,,Westfield,,Rocky De La Fuente. Michael,Independent,1,82048
-Chittenden,President,,Westford,,Rocky De La Fuente. Michael,Independent,5,82048
-Windham,President,,Westminster,Windham 3,Rocky De La Fuente. Michael,Independent,0,82048
-Windham,President,,Westminster,Windham 4,Rocky De La Fuente. Michael,Independent,5,82048
-Orleans,President,,Westmore,,Rocky De La Fuente. Michael,Independent,1,82048
-Windsor,President,,Weston,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Weybridge,,Rocky De La Fuente. Michael,Independent,1,82048
-Caledonia,President,,Wheelock,,Rocky De La Fuente. Michael,Independent,1,82048
-Addison,President,,Whiting,,Rocky De La Fuente. Michael,Independent,2,82048
-Windham,President,,Whitingham,Windham 6,Rocky De La Fuente. Michael,Independent,4,82048
-Windham,President,,Whitingham,Windham-Bennington,Rocky De La Fuente. Michael,Independent,0,82048
-Orange,President,,Williamstown,,Rocky De La Fuente. Michael,Independent,10,82048
-Chittenden,President,,Williston,,Rocky De La Fuente. Michael,Independent,15,82048
-Windham,President,,Wilmington,,Rocky De La Fuente. Michael,Independent,2,82048
-Windham,President,,Windham,,Rocky De La Fuente. Michael,Independent,3,82048
-Windsor,President,,Windsor,,Rocky De La Fuente. Michael,Independent,3,82048
-Bennington,President,,Winhall,,Rocky De La Fuente. Michael,Independent,2,82048
-Chittenden,President,,Winooski,,Rocky De La Fuente. Michael,Independent,14,82048
-Lamoille,President,,Wolcott,,Rocky De La Fuente. Michael,Independent,3,82048
-Washington,President,,Woodbury,,Rocky De La Fuente. Michael,Independent,3,82048
-Bennington,President,,Woodford,,Rocky De La Fuente. Michael,Independent,0,82048
-Windsor,President,,Woodstock,,Rocky De La Fuente. Michael,Independent,5,82048
-Washington,President,,Worcester,,Rocky De La Fuente. Michael,Independent,3,82048
-Addison,President,,Addison,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Albany,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Grand Isle,President,,Alburgh,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Andover,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Bennington,President,,Arlington,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Windham,President,,Athens,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Bakersfield,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Baltimore,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Barnard,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Barnet,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Barre City,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Washington,President,,Barre Town,,Gloria Lariva. Eugene Puryear,Liberty Union,6,82048
-Orleans,President,,Barton,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Lamoille,President,,Belvidere,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Bennington,Bennington 2-1,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Bennington,President,,Bennington,Bennington 2-2,Gloria Lariva. Eugene Puryear,Liberty Union,5,82048
-Rutland,President,,Benson,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Franklin,President,,Berkshire,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Berlin,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Bethel,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Essex,President,,Bloomfield,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Bolton,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Bradford,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Orange,President,,Braintree,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Brandon,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windham,President,,Brattleboro,Windham 2-1,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windham,President,,Brattleboro,Windham 2-2,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Windham,President,,Brattleboro,Windham 2-3,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Bridgewater,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Addison,President,,Bridport,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Essex,President,,Brighton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Bristol,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Brookfield,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Brookline,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Brownington,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Essex,President,,Brunswick,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Burke,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Burlington,Chittenden 6-1,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Chittenden,President,,Burlington,Chittenden 6-2,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Burlington,Chittenden 6-3,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Chittenden,President,,Burlington,Chittenden 6-4,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Chittenden,President,,Burlington,Chittenden 6-5,Gloria Lariva. Eugene Puryear,Liberty Union,5,82048
-Chittenden,President,,Burlington,Chittenden 6-6,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Burlington,Chittenden 6-7,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Cabot,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Calais,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Lamoille,President,,Cambridge,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Essex,President,,Canaan,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Castleton,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Windsor,President,,Cavendish,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Charleston,,Gloria Lariva. Eugene Puryear,Liberty Union,7,82048
-Chittenden,President,,Charlotte,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Orange,President,,Chelsea,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Chester,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Chittenden,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Clarendon,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Colchester,Chittenden 9-1,Gloria Lariva. Eugene Puryear,Liberty Union,8,82048
-Chittenden,President,,Colchester,Chittenden 9-2,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Essex,President,,Concord,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Corinth,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Cornwall,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Coventry,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Craftsbury,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Danby,,Gloria Lariva. Eugene Puryear,Liberty Union,5,82048
-Caledonia,President,,Danville,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Derby,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Dorset,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Dover,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Windham,President,,Dummerston,,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Washington,President,,Duxbury,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Essex,President,,East Haven,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,East Montpelier,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Lamoille,President,,Eden,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Lamoille,President,,Elmore,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Enosburgh,,Gloria Lariva. Eugene Puryear,Liberty Union,6,82048
-Chittenden,President,,Essex,Chittenden 8-1,Gloria Lariva. Eugene Puryear,Liberty Union,6,82048
-Chittenden,President,,Essex,Chittenden 8-2,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Chittenden,President,,Essex,Chittenden 8-3,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Fair Haven,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Franklin,President,,Fairfax,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Fairfield,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Fairlee,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Fayston,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Ferrisburgh,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Franklin,President,,Fletcher,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Franklin,President,,Franklin,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Georgia,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Orleans,President,,Glover,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Goshen,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Grafton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Essex,President,,Granby,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Grand Isle,President,,Grand Isle,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Addison,President,,Granville,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Greensboro,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Groton,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Essex,President,,Guildhall,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Guilford,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windham,President,,Halifax,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Hancock,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Hardwick,,Gloria Lariva. Eugene Puryear,Liberty Union,6,82048
-Windsor,President,,Hartford,Windsor 4-1,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Hartford,Windsor 4-2,Gloria Lariva. Eugene Puryear,Liberty Union,6,82048
-Windsor,President,,Hartland,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Franklin,President,,Highgate,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Chittenden,President,,Hinesburg,Chittenden 4-1,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Hinesburg,Chittenden 4-2,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Orleans,President,,Holland,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Hubbardton,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Chittenden,President,,Huntington,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Lamoille,President,,Hyde Park,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Rutland,President,,Ira,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Irasburg,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Grand Isle,President,,Isle La Motte,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Jamaica,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Orleans,President,,Jay,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Jericho,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Lamoille,President,,Johnson,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Killington,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Kirby,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Landgrove,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Leicester,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Essex,President,,Lemington,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Lincoln,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Londonderry,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Orleans,President,,Lowell,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windsor,President,,Ludlow,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Essex,President,,Lunenburg,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Caledonia,President,,Lyndon,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Essex,President,,Maidstone,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Manchester,,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Windham,President,,Marlboro,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Marshfield,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Mendon,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Middlebury,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Washington,President,,Middlesex,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Middletown Springs,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Milton,Chittenden 10,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Chittenden,President,,Milton,Grand Isle-Chittenden,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Monkton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Montgomery,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Montpelier,,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Washington,President,,Moretown,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Morgan,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Lamoille,President,,Morristown,,Gloria Lariva. Eugene Puryear,Liberty Union,7,82048
-Rutland,President,,Mount Holly,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Mount Tabor,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,New Haven,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Caledonia,President,,Newark,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Newbury,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windham,President,,Newfane,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Newport City,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orleans,President,,Newport Town,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Grand Isle,President,,North Hero,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Northfield,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Essex,President,,Norton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Norwich,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Orange,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Orwell,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Panton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Pawlet,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Caledonia,President,,Peacham,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Bennington,President,,Peru,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Pittsfield,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Pittsford,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Washington,President,,Plainfield,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windsor,President,,Plymouth,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Pomfret,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Poultney,,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Bennington,President,,Pownal,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Proctor,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windham,President,,Putney,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Orange,President,,Randolph,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windsor,President,,Reading,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Readsboro,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Franklin,President,,Richford,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Richmond,,Gloria Lariva. Eugene Puryear,Liberty Union,5,82048
-Addison,President,,Ripton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Rochester,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Rockingham,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Roxbury,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Royalton,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Bennington,President,,Rupert,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Rutland City,Rutland 5-1,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Rutland City,Rutland 5-2,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Rutland City,Rutland 5-3,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Rutland,President,,Rutland City,Rutland 5-4,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Rutland,President,,Rutland Town,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Caledonia,President,,Ryegate,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Salisbury,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Sandgate,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Bennington,President,,Searsburg,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Bennington,President,,Shaftsbury,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Sharon,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Sheffield,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Shelburne,Chittenden 5-1,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Shelburne,Chittenden 5-2,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Franklin,President,,Sheldon,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Shoreham,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Shrewsbury,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Chittenden,President,,South Burlington,Chittenden 7-1,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,South Burlington,Chittenden 7-2,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,South Burlington,Chittenden 7-3,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,South Burlington,Chittenden 7-4,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Grand Isle,President,,South Hero,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Springfield,Windsor 3-1,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Springfield,Windsor 3-2,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Franklin,President,,Saint Albans City,,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Franklin,President,,Saint Albans Town,Franklin 3-1,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Saint Albans Town,Franklin 3-2,Gloria Lariva. Eugene Puryear,Liberty Union,3,82048
-Chittenden,President,,Saint George,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Caledonia,President,,Saint Johnsbury,,Gloria Lariva. Eugene Puryear,Liberty Union,4,82048
-Bennington,President,,Stamford,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Stannard,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Starksboro,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Stockbridge,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Lamoille,President,,Stowe,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Strafford,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Stratton,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Sudbury,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Sunderland,Bennington 3,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Bennington,President,,Sunderland,Bennington 4,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Sutton,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Franklin,President,,Swanton,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Orange,President,,Thetford,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Tinmouth,Rutland 2,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,Tinmouth,Rutland-Bennington,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Topsham,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windham,President,,Townshend,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Troy,Orleans 2,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Troy,Orleans-Lamoille,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Tunbridge,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Underhill,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Vergennes,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windham,President,,Vernon,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Vershire,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Essex,President,,Victory,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Waitsfield,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Caledonia,President,,Walden,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Rutland,President,,Wallingford,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Waltham,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Wardsboro,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Warren,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Washington,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Washington,President,,Waterbury,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Caledonia,President,,Waterford,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Lamoille,President,,Waterville,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Weathersfield,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,Wells,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,West Fairlee,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Rutland,President,,West Haven,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Rutland,President,,West Rutland,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,West Windsor,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Westfield,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Chittenden,President,,Westford,,Gloria Lariva. Eugene Puryear,Liberty Union,5,82048
-Windham,President,,Westminster,Windham 3,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Westminster,Windham 4,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orleans,President,,Westmore,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windsor,President,,Weston,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Addison,President,,Weybridge,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Caledonia,President,,Wheelock,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Addison,President,,Whiting,,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Windham,President,,Whitingham,Windham 6,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windham,President,,Whitingham,Windham-Bennington,Gloria Lariva. Eugene Puryear,Liberty Union,0,82048
-Orange,President,,Williamstown,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Williston,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windham,President,,Wilmington,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Windham,President,,Windham,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Windsor,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Bennington,President,,Winhall,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Chittenden,President,,Winooski,,Gloria Lariva. Eugene Puryear,Liberty Union,7,82048
-Lamoille,President,,Wolcott,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Washington,President,,Woodbury,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Bennington,President,,Woodford,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
-Windsor,President,,Woodstock,,Gloria Lariva. Eugene Puryear,Liberty Union,2,82048
-Washington,President,,Worcester,,Gloria Lariva. Eugene Puryear,Liberty Union,1,82048
+Addison,President,,Addison,,Gary Johnson,Libertarian,47,82048
+Orleans,President,,Albany,,Gary Johnson,Libertarian,13,82048
+Grand Isle,President,,Alburgh,,Gary Johnson,Libertarian,29,82048
+Windsor,President,,Andover,,Gary Johnson,Libertarian,8,82048
+Bennington,President,,Arlington,,Gary Johnson,Libertarian,28,82048
+Windham,President,,Athens,,Gary Johnson,Libertarian,6,82048
+Franklin,President,,Bakersfield,,Gary Johnson,Libertarian,22,82048
+Windsor,President,,Baltimore,,Gary Johnson,Libertarian,9,82048
+Windsor,President,,Barnard,,Gary Johnson,Libertarian,13,82048
+Caledonia,President,,Barnet,,Gary Johnson,Libertarian,46,82048
+Washington,President,,Barre City,,Gary Johnson,Libertarian,109,82048
+Washington,President,,Barre Town,,Gary Johnson,Libertarian,139,82048
+Orleans,President,,Barton,,Gary Johnson,Libertarian,32,82048
+Lamoille,President,,Belvidere,,Gary Johnson,Libertarian,7,82048
+Bennington,President,,Bennington,Bennington 2-1,Gary Johnson,Libertarian,72,82048
+Bennington,President,,Bennington,Bennington 2-2,Gary Johnson,Libertarian,83,82048
+Rutland,President,,Benson,,Gary Johnson,Libertarian,23,82048
+Franklin,President,,Berkshire,,Gary Johnson,Libertarian,26,82048
+Washington,President,,Berlin,,Gary Johnson,Libertarian,51,82048
+Windsor,President,,Bethel,,Gary Johnson,Libertarian,33,82048
+Essex,President,,Bloomfield,,Gary Johnson,Libertarian,8,82048
+Chittenden,President,,Bolton,,Gary Johnson,Libertarian,14,82048
+Orange,President,,Bradford,,Gary Johnson,Libertarian,42,82048
+Orange,President,,Braintree,,Gary Johnson,Libertarian,21,82048
+Rutland,President,,Brandon,,Gary Johnson,Libertarian,49,82048
+Windham,President,,Brattleboro,Windham 2-1,Gary Johnson,Libertarian,31,82048
+Windham,President,,Brattleboro,Windham 2-2,Gary Johnson,Libertarian,32,82048
+Windham,President,,Brattleboro,Windham 2-3,Gary Johnson,Libertarian,32,82048
+Windsor,President,,Bridgewater,,Gary Johnson,Libertarian,11,82048
+Addison,President,,Bridport,,Gary Johnson,Libertarian,24,82048
+Essex,President,,Brighton,,Gary Johnson,Libertarian,17,82048
+Addison,President,,Bristol,,Gary Johnson,Libertarian,60,82048
+Orange,President,,Brookfield,,Gary Johnson,Libertarian,34,82048
+Windham,President,,Brookline,,Gary Johnson,Libertarian,12,82048
+Orleans,President,,Brownington,,Gary Johnson,Libertarian,8,82048
+Essex,President,,Brunswick,,Gary Johnson,Libertarian,2,82048
+Caledonia,President,,Burke,,Gary Johnson,Libertarian,34,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Gary Johnson,Libertarian,94,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Gary Johnson,Libertarian,52,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Gary Johnson,Libertarian,71,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Gary Johnson,Libertarian,44,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Gary Johnson,Libertarian,113,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Gary Johnson,Libertarian,34,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Gary Johnson,Libertarian,4,82048
+Washington,President,,Cabot,,Gary Johnson,Libertarian,37,82048
+Washington,President,,Calais,,Gary Johnson,Libertarian,21,82048
+Lamoille,President,,Cambridge,,Gary Johnson,Libertarian,89,82048
+Essex,President,,Canaan,,Gary Johnson,Libertarian,12,82048
+Rutland,President,,Castleton,,Gary Johnson,Libertarian,39,82048
+Windsor,President,,Cavendish,,Gary Johnson,Libertarian,20,82048
+Orleans,President,,Charleston,,Gary Johnson,Libertarian,17,82048
+Chittenden,President,,Charlotte,,Gary Johnson,Libertarian,79,82048
+Orange,President,,Chelsea,,Gary Johnson,Libertarian,22,82048
+Windsor,President,,Chester,,Gary Johnson,Libertarian,47,82048
+Rutland,President,,Chittenden,,Gary Johnson,Libertarian,21,82048
+Rutland,President,,Clarendon,,Gary Johnson,Libertarian,35,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Gary Johnson,Libertarian,107,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Gary Johnson,Libertarian,138,82048
+Essex,President,,Concord,,Gary Johnson,Libertarian,30,82048
+Orange,President,,Corinth,,Gary Johnson,Libertarian,19,82048
+Addison,President,,Cornwall,,Gary Johnson,Libertarian,22,82048
+Orleans,President,,Coventry,,Gary Johnson,Libertarian,16,82048
+Orleans,President,,Craftsbury,,Gary Johnson,Libertarian,26,82048
+Rutland,President,,Danby,,Gary Johnson,Libertarian,39,82048
+Caledonia,President,,Danville,,Gary Johnson,Libertarian,50,82048
+Orleans,President,,Derby,,Gary Johnson,Libertarian,82,82048
+Bennington,President,,Dorset,,Gary Johnson,Libertarian,36,82048
+Windham,President,,Dover,,Gary Johnson,Libertarian,24,82048
+Windham,President,,Dummerston,,Gary Johnson,Libertarian,31,82048
+Washington,President,,Duxbury,,Gary Johnson,Libertarian,38,82048
+Essex,President,,East Haven,,Gary Johnson,Libertarian,2,82048
+Washington,President,,East Montpelier,,Gary Johnson,Libertarian,41,82048
+Lamoille,President,,Eden,,Gary Johnson,Libertarian,17,82048
+Lamoille,President,,Elmore,,Gary Johnson,Libertarian,19,82048
+Franklin,President,,Enosburgh,,Gary Johnson,Libertarian,57,82048
+Chittenden,President,,Essex,Chittenden 8-1,Gary Johnson,Libertarian,168,82048
+Chittenden,President,,Essex,Chittenden 8-2,Gary Johnson,Libertarian,208,82048
+Chittenden,President,,Essex,Chittenden 8-3,Gary Johnson,Libertarian,42,82048
+Rutland,President,,Fair Haven,,Gary Johnson,Libertarian,23,82048
+Franklin,President,,Fairfax,,Gary Johnson,Libertarian,113,82048
+Franklin,President,,Fairfield,,Gary Johnson,Libertarian,41,82048
+Orange,President,,Fairlee,,Gary Johnson,Libertarian,17,82048
+Washington,President,,Fayston,,Gary Johnson,Libertarian,21,82048
+Addison,President,,Ferrisburgh,,Gary Johnson,Libertarian,61,82048
+Franklin,President,,Fletcher,,Gary Johnson,Libertarian,31,82048
+Franklin,President,,Franklin,,Gary Johnson,Libertarian,33,82048
+Franklin,President,,Georgia,,Gary Johnson,Libertarian,90,82048
+Orleans,President,,Glover,,Gary Johnson,Libertarian,31,82048
+Addison,President,,Goshen,,Gary Johnson,Libertarian,6,82048
+Windham,President,,Grafton,,Gary Johnson,Libertarian,14,82048
+Essex,President,,Granby,,Gary Johnson,Libertarian,1,82048
+Grand Isle,President,,Grand Isle,,Gary Johnson,Libertarian,39,82048
+Addison,President,,Granville,,Gary Johnson,Libertarian,3,82048
+Orleans,President,,Greensboro,,Gary Johnson,Libertarian,12,82048
+Caledonia,President,,Groton,,Gary Johnson,Libertarian,18,82048
+Essex,President,,Guildhall,,Gary Johnson,Libertarian,10,82048
+Windham,President,,Guilford,,Gary Johnson,Libertarian,29,82048
+Windham,President,,Halifax,,Gary Johnson,Libertarian,10,82048
+Addison,President,,Hancock,,Gary Johnson,Libertarian,6,82048
+Caledonia,President,,Hardwick,,Gary Johnson,Libertarian,42,82048
+Windsor,President,,Hartford,Windsor 4-1,Gary Johnson,Libertarian,51,82048
+Windsor,President,,Hartford,Windsor 4-2,Gary Johnson,Libertarian,123,82048
+Windsor,President,,Hartland,,Gary Johnson,Libertarian,52,82048
+Franklin,President,,Highgate,,Gary Johnson,Libertarian,42,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Gary Johnson,Libertarian,0,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Gary Johnson,Libertarian,81,82048
+Orleans,President,,Holland,,Gary Johnson,Libertarian,10,82048
+Rutland,President,,Hubbardton,,Gary Johnson,Libertarian,12,82048
+Chittenden,President,,Huntington,,Gary Johnson,Libertarian,44,82048
+Lamoille,President,,Hyde Park,,Gary Johnson,Libertarian,48,82048
+Rutland,President,,Ira,,Gary Johnson,Libertarian,8,82048
+Orleans,President,,Irasburg,,Gary Johnson,Libertarian,27,82048
+Grand Isle,President,,Isle La Motte,,Gary Johnson,Libertarian,12,82048
+Windham,President,,Jamaica,,Gary Johnson,Libertarian,24,82048
+Orleans,President,,Jay,,Gary Johnson,Libertarian,6,82048
+Chittenden,President,,Jericho,,Gary Johnson,Libertarian,101,82048
+Lamoille,President,,Johnson,,Gary Johnson,Libertarian,45,82048
+Rutland,President,,Killington,,Gary Johnson,Libertarian,29,82048
+Caledonia,President,,Kirby,,Gary Johnson,Libertarian,6,82048
+Bennington,President,,Landgrove,,Gary Johnson,Libertarian,5,82048
+Addison,President,,Leicester,,Gary Johnson,Libertarian,15,82048
+Essex,President,,Lemington,,Gary Johnson,Libertarian,6,82048
+Addison,President,,Lincoln,,Gary Johnson,Libertarian,22,82048
+Windham,President,,Londonderry,,Gary Johnson,Libertarian,30,82048
+Orleans,President,,Lowell,,Gary Johnson,Libertarian,11,82048
+Windsor,President,,Ludlow,,Gary Johnson,Libertarian,28,82048
+Essex,President,,Lunenburg,,Gary Johnson,Libertarian,20,82048
+Caledonia,President,,Lyndon,,Gary Johnson,Libertarian,86,82048
+Essex,President,,Maidstone,,Gary Johnson,Libertarian,6,82048
+Bennington,President,,Manchester,,Gary Johnson,Libertarian,74,82048
+Windham,President,,Marlboro,,Gary Johnson,Libertarian,5,82048
+Washington,President,,Marshfield,,Gary Johnson,Libertarian,27,82048
+Rutland,President,,Mendon,,Gary Johnson,Libertarian,26,82048
+Addison,President,,Middlebury,,Gary Johnson,Libertarian,77,82048
+Washington,President,,Middlesex,,Gary Johnson,Libertarian,31,82048
+Rutland,President,,Middletown Springs,,Gary Johnson,Libertarian,8,82048
+Chittenden,President,,Milton,Chittenden 10,Gary Johnson,Libertarian,123,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Gary Johnson,Libertarian,26,82048
+Addison,President,,Monkton,,Gary Johnson,Libertarian,57,82048
+Franklin,President,,Montgomery,,Gary Johnson,Libertarian,21,82048
+Washington,President,,Montpelier,,Gary Johnson,Libertarian,98,82048
+Washington,President,,Moretown,,Gary Johnson,Libertarian,42,82048
+Orleans,President,,Morgan,,Gary Johnson,Libertarian,10,82048
+Lamoille,President,,Morristown,,Gary Johnson,Libertarian,81,82048
+Rutland,President,,Mount Holly,,Gary Johnson,Libertarian,25,82048
+Rutland,President,,Mount Tabor,,Gary Johnson,Libertarian,5,82048
+Addison,President,,New Haven,,Gary Johnson,Libertarian,45,82048
+Caledonia,President,,Newark,,Gary Johnson,Libertarian,16,82048
+Orange,President,,Newbury,,Gary Johnson,Libertarian,28,82048
+Windham,President,,Newfane,,Gary Johnson,Libertarian,14,82048
+Orleans,President,,Newport City,,Gary Johnson,Libertarian,34,82048
+Orleans,President,,Newport Town,,Gary Johnson,Libertarian,31,82048
+Grand Isle,President,,North Hero,,Gary Johnson,Libertarian,15,82048
+Washington,President,,Northfield,,Gary Johnson,Libertarian,105,82048
+Essex,President,,Norton,,Gary Johnson,Libertarian,4,82048
+Windsor,President,,Norwich,,Gary Johnson,Libertarian,36,82048
+Orange,President,,Orange,,Gary Johnson,Libertarian,22,82048
+Addison,President,,Orwell,,Gary Johnson,Libertarian,29,82048
+Addison,President,,Panton,,Gary Johnson,Libertarian,6,82048
+Rutland,President,,Pawlet,,Gary Johnson,Libertarian,23,82048
+Caledonia,President,,Peacham,,Gary Johnson,Libertarian,25,82048
+Bennington,President,,Peru,,Gary Johnson,Libertarian,4,82048
+Rutland,President,,Pittsfield,,Gary Johnson,Libertarian,8,82048
+Rutland,President,,Pittsford,,Gary Johnson,Libertarian,65,82048
+Washington,President,,Plainfield,,Gary Johnson,Libertarian,16,82048
+Windsor,President,,Plymouth,,Gary Johnson,Libertarian,13,82048
+Windsor,President,,Pomfret,,Gary Johnson,Libertarian,21,82048
+Rutland,President,,Poultney,,Gary Johnson,Libertarian,49,82048
+Bennington,President,,Pownal,,Gary Johnson,Libertarian,47,82048
+Rutland,President,,Proctor,,Gary Johnson,Libertarian,34,82048
+Windham,President,,Putney,,Gary Johnson,Libertarian,32,82048
+Orange,President,,Randolph,,Gary Johnson,Libertarian,78,82048
+Windsor,President,,Reading,,Gary Johnson,Libertarian,11,82048
+Bennington,President,,Readsboro,,Gary Johnson,Libertarian,7,82048
+Franklin,President,,Richford,,Gary Johnson,Libertarian,21,82048
+Chittenden,President,,Richmond,,Gary Johnson,Libertarian,100,82048
+Addison,President,,Ripton,,Gary Johnson,Libertarian,5,82048
+Windsor,President,,Rochester,,Gary Johnson,Libertarian,17,82048
+Windham,President,,Rockingham,,Gary Johnson,Libertarian,75,82048
+Washington,President,,Roxbury,,Gary Johnson,Libertarian,21,82048
+Windsor,President,,Royalton,,Gary Johnson,Libertarian,46,82048
+Bennington,President,,Rupert,,Gary Johnson,Libertarian,14,82048
+Rutland,President,,Rutland City,Rutland 5-1,Gary Johnson,Libertarian,68,82048
+Rutland,President,,Rutland City,Rutland 5-2,Gary Johnson,Libertarian,44,82048
+Rutland,President,,Rutland City,Rutland 5-3,Gary Johnson,Libertarian,42,82048
+Rutland,President,,Rutland City,Rutland 5-4,Gary Johnson,Libertarian,55,82048
+Rutland,President,,Rutland Town,,Gary Johnson,Libertarian,88,82048
+Caledonia,President,,Ryegate,,Gary Johnson,Libertarian,15,82048
+Addison,President,,Salisbury,,Gary Johnson,Libertarian,8,82048
+Bennington,President,,Sandgate,,Gary Johnson,Libertarian,6,82048
+Bennington,President,,Searsburg,,Gary Johnson,Libertarian,0,82048
+Bennington,President,,Shaftsbury,,Gary Johnson,Libertarian,53,82048
+Windsor,President,,Sharon,,Gary Johnson,Libertarian,15,82048
+Caledonia,President,,Sheffield,,Gary Johnson,Libertarian,14,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Gary Johnson,Libertarian,51,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Gary Johnson,Libertarian,60,82048
+Franklin,President,,Sheldon,,Gary Johnson,Libertarian,31,82048
+Addison,President,,Shoreham,,Gary Johnson,Libertarian,19,82048
+Rutland,President,,Shrewsbury,,Gary Johnson,Libertarian,16,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Gary Johnson,Libertarian,67,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Gary Johnson,Libertarian,97,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Gary Johnson,Libertarian,69,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Gary Johnson,Libertarian,89,82048
+Grand Isle,President,,South Hero,,Gary Johnson,Libertarian,36,82048
+Windsor,President,,Springfield,Windsor 3-1,Gary Johnson,Libertarian,3,82048
+Windsor,President,,Springfield,Windsor 3-2,Gary Johnson,Libertarian,141,82048
+Franklin,President,,Saint Albans City,,Gary Johnson,Libertarian,120,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Gary Johnson,Libertarian,45,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Gary Johnson,Libertarian,61,82048
+Chittenden,President,,Saint George,,Gary Johnson,Libertarian,7,82048
+Caledonia,President,,Saint Johnsbury,,Gary Johnson,Libertarian,125,82048
+Bennington,President,,Stamford,,Gary Johnson,Libertarian,16,82048
+Caledonia,President,,Stannard,,Gary Johnson,Libertarian,5,82048
+Addison,President,,Starksboro,,Gary Johnson,Libertarian,36,82048
+Windsor,President,,Stockbridge,,Gary Johnson,Libertarian,7,82048
+Lamoille,President,,Stowe,,Gary Johnson,Libertarian,113,82048
+Orange,President,,Strafford,,Gary Johnson,Libertarian,24,82048
+Windham,President,,Stratton,,Gary Johnson,Libertarian,2,82048
+Rutland,President,,Sudbury,,Gary Johnson,Libertarian,12,82048
+Bennington,President,,Sunderland,Bennington 3,Gary Johnson,Libertarian,5,82048
+Bennington,President,,Sunderland,Bennington 4,Gary Johnson,Libertarian,7,82048
+Caledonia,President,,Sutton,,Gary Johnson,Libertarian,24,82048
+Franklin,President,,Swanton,,Gary Johnson,Libertarian,82,82048
+Orange,President,,Thetford,,Gary Johnson,Libertarian,45,82048
+Rutland,President,,Tinmouth,Rutland 2,Gary Johnson,Libertarian,2,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Gary Johnson,Libertarian,13,82048
+Orange,President,,Topsham,,Gary Johnson,Libertarian,19,82048
+Windham,President,,Townshend,,Gary Johnson,Libertarian,17,82048
+Orleans,President,,Troy,Orleans 2,Gary Johnson,Libertarian,6,82048
+Orleans,President,,Troy,Orleans-Lamoille,Gary Johnson,Libertarian,13,82048
+Orange,President,,Tunbridge,,Gary Johnson,Libertarian,21,82048
+Chittenden,President,,Underhill,,Gary Johnson,Libertarian,55,82048
+Addison,President,,Vergennes,,Gary Johnson,Libertarian,51,82048
+Windham,President,,Vernon,,Gary Johnson,Libertarian,50,82048
+Orange,President,,Vershire,,Gary Johnson,Libertarian,10,82048
+Essex,President,,Victory,,Gary Johnson,Libertarian,3,82048
+Washington,President,,Waitsfield,,Gary Johnson,Libertarian,29,82048
+Caledonia,President,,Walden,,Gary Johnson,Libertarian,22,82048
+Rutland,President,,Wallingford,,Gary Johnson,Libertarian,35,82048
+Addison,President,,Waltham,,Gary Johnson,Libertarian,14,82048
+Windham,President,,Wardsboro,,Gary Johnson,Libertarian,12,82048
+Washington,President,,Warren,,Gary Johnson,Libertarian,45,82048
+Orange,President,,Washington,,Gary Johnson,Libertarian,24,82048
+Washington,President,,Waterbury,,Gary Johnson,Libertarian,91,82048
+Caledonia,President,,Waterford,,Gary Johnson,Libertarian,37,82048
+Lamoille,President,,Waterville,,Gary Johnson,Libertarian,14,82048
+Windsor,President,,Weathersfield,,Gary Johnson,Libertarian,51,82048
+Rutland,President,,Wells,,Gary Johnson,Libertarian,17,82048
+Orange,President,,West Fairlee,,Gary Johnson,Libertarian,15,82048
+Rutland,President,,West Haven,,Gary Johnson,Libertarian,0,82048
+Rutland,President,,West Rutland,,Gary Johnson,Libertarian,33,82048
+Windsor,President,,West Windsor,,Gary Johnson,Libertarian,27,82048
+Orleans,President,,Westfield,,Gary Johnson,Libertarian,6,82048
+Chittenden,President,,Westford,,Gary Johnson,Libertarian,58,82048
+Windham,President,,Westminster,Windham 3,Gary Johnson,Libertarian,0,82048
+Windham,President,,Westminster,Windham 4,Gary Johnson,Libertarian,32,82048
+Orleans,President,,Westmore,,Gary Johnson,Libertarian,7,82048
+Windsor,President,,Weston,,Gary Johnson,Libertarian,8,82048
+Addison,President,,Weybridge,,Gary Johnson,Libertarian,18,82048
+Caledonia,President,,Wheelock,,Gary Johnson,Libertarian,13,82048
+Addison,President,,Whiting,,Gary Johnson,Libertarian,8,82048
+Windham,President,,Whitingham,Windham 6,Gary Johnson,Libertarian,22,82048
+Windham,President,,Whitingham,Windham-Bennington,Gary Johnson,Libertarian,0,82048
+Orange,President,,Williamstown,,Gary Johnson,Libertarian,72,82048
+Chittenden,President,,Williston,,Gary Johnson,Libertarian,195,82048
+Windham,President,,Wilmington,,Gary Johnson,Libertarian,36,82048
+Windham,President,,Windham,,Gary Johnson,Libertarian,10,82048
+Windsor,President,,Windsor,,Gary Johnson,Libertarian,92,82048
+Bennington,President,,Winhall,,Gary Johnson,Libertarian,15,82048
+Chittenden,President,,Winooski,,Gary Johnson,Libertarian,78,82048
+Lamoille,President,,Wolcott,,Gary Johnson,Libertarian,24,82048
+Washington,President,,Woodbury,,Gary Johnson,Libertarian,18,82048
+Bennington,President,,Woodford,,Gary Johnson,Libertarian,6,82048
+Windsor,President,,Woodstock,,Gary Johnson,Libertarian,48,82048
+Washington,President,,Worcester,,Gary Johnson,Libertarian,19,82048
+Addison,President,,Addison,,Jill Stein,Green,8,82048
+Orleans,President,,Albany,,Jill Stein,Green,9,82048
+Grand Isle,President,,Alburgh,,Jill Stein,Green,8,82048
+Windsor,President,,Andover,,Jill Stein,Green,4,82048
+Bennington,President,,Arlington,,Jill Stein,Green,22,82048
+Windham,President,,Athens,,Jill Stein,Green,8,82048
+Franklin,President,,Bakersfield,,Jill Stein,Green,10,82048
+Windsor,President,,Baltimore,,Jill Stein,Green,2,82048
+Windsor,President,,Barnard,,Jill Stein,Green,11,82048
+Caledonia,President,,Barnet,,Jill Stein,Green,21,82048
+Washington,President,,Barre City,,Jill Stein,Green,66,82048
+Washington,President,,Barre Town,,Jill Stein,Green,55,82048
+Orleans,President,,Barton,,Jill Stein,Green,5,82048
+Lamoille,President,,Belvidere,,Jill Stein,Green,1,82048
+Bennington,President,,Bennington,Bennington 2-1,Jill Stein,Green,63,82048
+Bennington,President,,Bennington,Bennington 2-2,Jill Stein,Green,84,82048
+Rutland,President,,Benson,,Jill Stein,Green,10,82048
+Franklin,President,,Berkshire,,Jill Stein,Green,5,82048
+Washington,President,,Berlin,,Jill Stein,Green,31,82048
+Windsor,President,,Bethel,,Jill Stein,Green,36,82048
+Essex,President,,Bloomfield,,Jill Stein,Green,6,82048
+Chittenden,President,,Bolton,,Jill Stein,Green,8,82048
+Orange,President,,Bradford,,Jill Stein,Green,23,82048
+Orange,President,,Braintree,,Jill Stein,Green,9,82048
+Rutland,President,,Brandon,,Jill Stein,Green,33,82048
+Windham,President,,Brattleboro,Windham 2-1,Jill Stein,Green,51,82048
+Windham,President,,Brattleboro,Windham 2-2,Jill Stein,Green,110,82048
+Windham,President,,Brattleboro,Windham 2-3,Jill Stein,Green,75,82048
+Windsor,President,,Bridgewater,,Jill Stein,Green,13,82048
+Addison,President,,Bridport,,Jill Stein,Green,8,82048
+Essex,President,,Brighton,,Jill Stein,Green,8,82048
+Addison,President,,Bristol,,Jill Stein,Green,41,82048
+Orange,President,,Brookfield,,Jill Stein,Green,26,82048
+Windham,President,,Brookline,,Jill Stein,Green,6,82048
+Orleans,President,,Brownington,,Jill Stein,Green,2,82048
+Essex,President,,Brunswick,,Jill Stein,Green,0,82048
+Caledonia,President,,Burke,,Jill Stein,Green,13,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Jill Stein,Green,81,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Jill Stein,Green,90,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Jill Stein,Green,225,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Jill Stein,Green,96,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Jill Stein,Green,164,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Jill Stein,Green,29,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Jill Stein,Green,4,82048
+Washington,President,,Cabot,,Jill Stein,Green,32,82048
+Washington,President,,Calais,,Jill Stein,Green,42,82048
+Lamoille,President,,Cambridge,,Jill Stein,Green,41,82048
+Essex,President,,Canaan,,Jill Stein,Green,2,82048
+Rutland,President,,Castleton,,Jill Stein,Green,22,82048
+Windsor,President,,Cavendish,,Jill Stein,Green,19,82048
+Orleans,President,,Charleston,,Jill Stein,Green,13,82048
+Chittenden,President,,Charlotte,,Jill Stein,Green,54,82048
+Orange,President,,Chelsea,,Jill Stein,Green,12,82048
+Windsor,President,,Chester,,Jill Stein,Green,34,82048
+Rutland,President,,Chittenden,,Jill Stein,Green,11,82048
+Rutland,President,,Clarendon,,Jill Stein,Green,11,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Jill Stein,Green,56,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Jill Stein,Green,64,82048
+Essex,President,,Concord,,Jill Stein,Green,3,82048
+Orange,President,,Corinth,,Jill Stein,Green,14,82048
+Addison,President,,Cornwall,,Jill Stein,Green,14,82048
+Orleans,President,,Coventry,,Jill Stein,Green,5,82048
+Orleans,President,,Craftsbury,,Jill Stein,Green,25,82048
+Rutland,President,,Danby,,Jill Stein,Green,15,82048
+Caledonia,President,,Danville,,Jill Stein,Green,22,82048
+Orleans,President,,Derby,,Jill Stein,Green,36,82048
+Bennington,President,,Dorset,,Jill Stein,Green,18,82048
+Windham,President,,Dover,,Jill Stein,Green,14,82048
+Windham,President,,Dummerston,,Jill Stein,Green,27,82048
+Washington,President,,Duxbury,,Jill Stein,Green,18,82048
+Essex,President,,East Haven,,Jill Stein,Green,6,82048
+Washington,President,,East Montpelier,,Jill Stein,Green,62,82048
+Lamoille,President,,Eden,,Jill Stein,Green,18,82048
+Lamoille,President,,Elmore,,Jill Stein,Green,16,82048
+Franklin,President,,Enosburgh,,Jill Stein,Green,22,82048
+Chittenden,President,,Essex,Chittenden 8-1,Jill Stein,Green,54,82048
+Chittenden,President,,Essex,Chittenden 8-2,Jill Stein,Green,84,82048
+Chittenden,President,,Essex,Chittenden 8-3,Jill Stein,Green,17,82048
+Rutland,President,,Fair Haven,,Jill Stein,Green,17,82048
+Franklin,President,,Fairfax,,Jill Stein,Green,42,82048
+Franklin,President,,Fairfield,,Jill Stein,Green,12,82048
+Orange,President,,Fairlee,,Jill Stein,Green,11,82048
+Washington,President,,Fayston,,Jill Stein,Green,23,82048
+Addison,President,,Ferrisburgh,,Jill Stein,Green,21,82048
+Franklin,President,,Fletcher,,Jill Stein,Green,23,82048
+Franklin,President,,Franklin,,Jill Stein,Green,4,82048
+Franklin,President,,Georgia,,Jill Stein,Green,38,82048
+Orleans,President,,Glover,,Jill Stein,Green,15,82048
+Addison,President,,Goshen,,Jill Stein,Green,3,82048
+Windham,President,,Grafton,,Jill Stein,Green,6,82048
+Essex,President,,Granby,,Jill Stein,Green,3,82048
+Grand Isle,President,,Grand Isle,,Jill Stein,Green,13,82048
+Addison,President,,Granville,,Jill Stein,Green,6,82048
+Orleans,President,,Greensboro,,Jill Stein,Green,11,82048
+Caledonia,President,,Groton,,Jill Stein,Green,16,82048
+Essex,President,,Guildhall,,Jill Stein,Green,3,82048
+Windham,President,,Guilford,,Jill Stein,Green,44,82048
+Windham,President,,Halifax,,Jill Stein,Green,12,82048
+Addison,President,,Hancock,,Jill Stein,Green,4,82048
+Caledonia,President,,Hardwick,,Jill Stein,Green,49,82048
+Windsor,President,,Hartford,Windsor 4-1,Jill Stein,Green,20,82048
+Windsor,President,,Hartford,Windsor 4-2,Jill Stein,Green,73,82048
+Windsor,President,,Hartland,,Jill Stein,Green,38,82048
+Franklin,President,,Highgate,,Jill Stein,Green,11,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Jill Stein,Green,0,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Jill Stein,Green,57,82048
+Orleans,President,,Holland,,Jill Stein,Green,2,82048
+Rutland,President,,Hubbardton,,Jill Stein,Green,6,82048
+Chittenden,President,,Huntington,,Jill Stein,Green,35,82048
+Lamoille,President,,Hyde Park,,Jill Stein,Green,37,82048
+Rutland,President,,Ira,,Jill Stein,Green,19,82048
+Orleans,President,,Irasburg,,Jill Stein,Green,2,82048
+Grand Isle,President,,Isle La Motte,,Jill Stein,Green,5,82048
+Windham,President,,Jamaica,,Jill Stein,Green,11,82048
+Orleans,President,,Jay,,Jill Stein,Green,3,82048
+Chittenden,President,,Jericho,,Jill Stein,Green,54,82048
+Lamoille,President,,Johnson,,Jill Stein,Green,48,82048
+Rutland,President,,Killington,,Jill Stein,Green,10,82048
+Caledonia,President,,Kirby,,Jill Stein,Green,8,82048
+Bennington,President,,Landgrove,,Jill Stein,Green,1,82048
+Addison,President,,Leicester,,Jill Stein,Green,5,82048
+Essex,President,,Lemington,,Jill Stein,Green,1,82048
+Addison,President,,Lincoln,,Jill Stein,Green,27,82048
+Windham,President,,Londonderry,,Jill Stein,Green,27,82048
+Orleans,President,,Lowell,,Jill Stein,Green,4,82048
+Windsor,President,,Ludlow,,Jill Stein,Green,23,82048
+Essex,President,,Lunenburg,,Jill Stein,Green,9,82048
+Caledonia,President,,Lyndon,,Jill Stein,Green,43,82048
+Essex,President,,Maidstone,,Jill Stein,Green,1,82048
+Bennington,President,,Manchester,,Jill Stein,Green,33,82048
+Windham,President,,Marlboro,,Jill Stein,Green,21,82048
+Washington,President,,Marshfield,,Jill Stein,Green,51,82048
+Rutland,President,,Mendon,,Jill Stein,Green,10,82048
+Addison,President,,Middlebury,,Jill Stein,Green,71,82048
+Washington,President,,Middlesex,,Jill Stein,Green,47,82048
+Rutland,President,,Middletown Springs,,Jill Stein,Green,18,82048
+Chittenden,President,,Milton,Chittenden 10,Jill Stein,Green,63,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Jill Stein,Green,7,82048
+Addison,President,,Monkton,,Jill Stein,Green,16,82048
+Franklin,President,,Montgomery,,Jill Stein,Green,19,82048
+Washington,President,,Montpelier,,Jill Stein,Green,208,82048
+Washington,President,,Moretown,,Jill Stein,Green,22,82048
+Orleans,President,,Morgan,,Jill Stein,Green,2,82048
+Lamoille,President,,Morristown,,Jill Stein,Green,89,82048
+Rutland,President,,Mount Holly,,Jill Stein,Green,15,82048
+Rutland,President,,Mount Tabor,,Jill Stein,Green,0,82048
+Addison,President,,New Haven,,Jill Stein,Green,21,82048
+Caledonia,President,,Newark,,Jill Stein,Green,13,82048
+Orange,President,,Newbury,,Jill Stein,Green,21,82048
+Windham,President,,Newfane,,Jill Stein,Green,42,82048
+Orleans,President,,Newport City,,Jill Stein,Green,19,82048
+Orleans,President,,Newport Town,,Jill Stein,Green,16,82048
+Grand Isle,President,,North Hero,,Jill Stein,Green,6,82048
+Washington,President,,Northfield,,Jill Stein,Green,49,82048
+Essex,President,,Norton,,Jill Stein,Green,0,82048
+Windsor,President,,Norwich,,Jill Stein,Green,33,82048
+Orange,President,,Orange,,Jill Stein,Green,17,82048
+Addison,President,,Orwell,,Jill Stein,Green,16,82048
+Addison,President,,Panton,,Jill Stein,Green,6,82048
+Rutland,President,,Pawlet,,Jill Stein,Green,9,82048
+Caledonia,President,,Peacham,,Jill Stein,Green,11,82048
+Bennington,President,,Peru,,Jill Stein,Green,2,82048
+Rutland,President,,Pittsfield,,Jill Stein,Green,5,82048
+Rutland,President,,Pittsford,,Jill Stein,Green,19,82048
+Washington,President,,Plainfield,,Jill Stein,Green,42,82048
+Windsor,President,,Plymouth,,Jill Stein,Green,9,82048
+Windsor,President,,Pomfret,,Jill Stein,Green,7,82048
+Rutland,President,,Poultney,,Jill Stein,Green,37,82048
+Bennington,President,,Pownal,,Jill Stein,Green,29,82048
+Rutland,President,,Proctor,,Jill Stein,Green,12,82048
+Windham,President,,Putney,,Jill Stein,Green,40,82048
+Orange,President,,Randolph,,Jill Stein,Green,67,82048
+Windsor,President,,Reading,,Jill Stein,Green,7,82048
+Bennington,President,,Readsboro,,Jill Stein,Green,7,82048
+Franklin,President,,Richford,,Jill Stein,Green,15,82048
+Chittenden,President,,Richmond,,Jill Stein,Green,49,82048
+Addison,President,,Ripton,,Jill Stein,Green,13,82048
+Windsor,President,,Rochester,,Jill Stein,Green,17,82048
+Windham,President,,Rockingham,,Jill Stein,Green,46,82048
+Washington,President,,Roxbury,,Jill Stein,Green,14,82048
+Windsor,President,,Royalton,,Jill Stein,Green,31,82048
+Bennington,President,,Rupert,,Jill Stein,Green,6,82048
+Rutland,President,,Rutland City,Rutland 5-1,Jill Stein,Green,27,82048
+Rutland,President,,Rutland City,Rutland 5-2,Jill Stein,Green,34,82048
+Rutland,President,,Rutland City,Rutland 5-3,Jill Stein,Green,24,82048
+Rutland,President,,Rutland City,Rutland 5-4,Jill Stein,Green,24,82048
+Rutland,President,,Rutland Town,,Jill Stein,Green,19,82048
+Caledonia,President,,Ryegate,,Jill Stein,Green,12,82048
+Addison,President,,Salisbury,,Jill Stein,Green,9,82048
+Bennington,President,,Sandgate,,Jill Stein,Green,7,82048
+Bennington,President,,Searsburg,,Jill Stein,Green,0,82048
+Bennington,President,,Shaftsbury,,Jill Stein,Green,26,82048
+Windsor,President,,Sharon,,Jill Stein,Green,25,82048
+Caledonia,President,,Sheffield,,Jill Stein,Green,6,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Jill Stein,Green,48,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Jill Stein,Green,31,82048
+Franklin,President,,Sheldon,,Jill Stein,Green,11,82048
+Addison,President,,Shoreham,,Jill Stein,Green,13,82048
+Rutland,President,,Shrewsbury,,Jill Stein,Green,9,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Jill Stein,Green,39,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Jill Stein,Green,35,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Jill Stein,Green,61,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Jill Stein,Green,61,82048
+Grand Isle,President,,South Hero,,Jill Stein,Green,18,82048
+Windsor,President,,Springfield,Windsor 3-1,Jill Stein,Green,3,82048
+Windsor,President,,Springfield,Windsor 3-2,Jill Stein,Green,82,82048
+Franklin,President,,Saint Albans City,,Jill Stein,Green,43,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Jill Stein,Green,9,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Jill Stein,Green,23,82048
+Chittenden,President,,Saint George,,Jill Stein,Green,6,82048
+Caledonia,President,,Saint Johnsbury,,Jill Stein,Green,64,82048
+Bennington,President,,Stamford,,Jill Stein,Green,6,82048
+Caledonia,President,,Stannard,,Jill Stein,Green,1,82048
+Addison,President,,Starksboro,,Jill Stein,Green,24,82048
+Windsor,President,,Stockbridge,,Jill Stein,Green,13,82048
+Lamoille,President,,Stowe,,Jill Stein,Green,39,82048
+Orange,President,,Strafford,,Jill Stein,Green,30,82048
+Windham,President,,Stratton,,Jill Stein,Green,0,82048
+Rutland,President,,Sudbury,,Jill Stein,Green,3,82048
+Bennington,President,,Sunderland,Bennington 3,Jill Stein,Green,3,82048
+Bennington,President,,Sunderland,Bennington 4,Jill Stein,Green,3,82048
+Caledonia,President,,Sutton,,Jill Stein,Green,11,82048
+Franklin,President,,Swanton,,Jill Stein,Green,33,82048
+Orange,President,,Thetford,,Jill Stein,Green,34,82048
+Rutland,President,,Tinmouth,Rutland 2,Jill Stein,Green,1,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Jill Stein,Green,2,82048
+Orange,President,,Topsham,,Jill Stein,Green,8,82048
+Windham,President,,Townshend,,Jill Stein,Green,10,82048
+Orleans,President,,Troy,Orleans 2,Jill Stein,Green,3,82048
+Orleans,President,,Troy,Orleans-Lamoille,Jill Stein,Green,7,82048
+Orange,President,,Tunbridge,,Jill Stein,Green,22,82048
+Chittenden,President,,Underhill,,Jill Stein,Green,26,82048
+Addison,President,,Vergennes,,Jill Stein,Green,23,82048
+Windham,President,,Vernon,,Jill Stein,Green,11,82048
+Orange,President,,Vershire,,Jill Stein,Green,18,82048
+Essex,President,,Victory,,Jill Stein,Green,1,82048
+Washington,President,,Waitsfield,,Jill Stein,Green,35,82048
+Caledonia,President,,Walden,,Jill Stein,Green,25,82048
+Rutland,President,,Wallingford,,Jill Stein,Green,22,82048
+Addison,President,,Waltham,,Jill Stein,Green,2,82048
+Windham,President,,Wardsboro,,Jill Stein,Green,11,82048
+Washington,President,,Warren,,Jill Stein,Green,25,82048
+Orange,President,,Washington,,Jill Stein,Green,11,82048
+Washington,President,,Waterbury,,Jill Stein,Green,44,82048
+Caledonia,President,,Waterford,,Jill Stein,Green,5,82048
+Lamoille,President,,Waterville,,Jill Stein,Green,10,82048
+Windsor,President,,Weathersfield,,Jill Stein,Green,26,82048
+Rutland,President,,Wells,,Jill Stein,Green,6,82048
+Orange,President,,West Fairlee,,Jill Stein,Green,2,82048
+Rutland,President,,West Haven,,Jill Stein,Green,7,82048
+Rutland,President,,West Rutland,,Jill Stein,Green,10,82048
+Windsor,President,,West Windsor,,Jill Stein,Green,6,82048
+Orleans,President,,Westfield,,Jill Stein,Green,11,82048
+Chittenden,President,,Westford,,Jill Stein,Green,22,82048
+Windham,President,,Westminster,Windham 3,Jill Stein,Green,4,82048
+Windham,President,,Westminster,Windham 4,Jill Stein,Green,57,82048
+Orleans,President,,Westmore,,Jill Stein,Green,4,82048
+Windsor,President,,Weston,,Jill Stein,Green,5,82048
+Addison,President,,Weybridge,,Jill Stein,Green,8,82048
+Caledonia,President,,Wheelock,,Jill Stein,Green,13,82048
+Addison,President,,Whiting,,Jill Stein,Green,2,82048
+Windham,President,,Whitingham,Windham 6,Jill Stein,Green,10,82048
+Windham,President,,Whitingham,Windham-Bennington,Jill Stein,Green,0,82048
+Orange,President,,Williamstown,,Jill Stein,Green,25,82048
+Chittenden,President,,Williston,,Jill Stein,Green,69,82048
+Windham,President,,Wilmington,,Jill Stein,Green,26,82048
+Windham,President,,Windham,,Jill Stein,Green,8,82048
+Windsor,President,,Windsor,,Jill Stein,Green,44,82048
+Bennington,President,,Winhall,,Jill Stein,Green,7,82048
+Chittenden,President,,Winooski,,Jill Stein,Green,107,82048
+Lamoille,President,,Wolcott,,Jill Stein,Green,27,82048
+Washington,President,,Woodbury,,Jill Stein,Green,18,82048
+Bennington,President,,Woodford,,Jill Stein,Green,1,82048
+Windsor,President,,Woodstock,,Jill Stein,Green,31,82048
+Washington,President,,Worcester,,Jill Stein,Green,27,82048
+Addison,President,,Addison,,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Albany,,Rocky De La Fuente,Independent,3,82048
+Grand Isle,President,,Alburgh,,Rocky De La Fuente,Independent,5,82048
+Windsor,President,,Andover,,Rocky De La Fuente,Independent,1,82048
+Bennington,President,,Arlington,,Rocky De La Fuente,Independent,4,82048
+Windham,President,,Athens,,Rocky De La Fuente,Independent,1,82048
+Franklin,President,,Bakersfield,,Rocky De La Fuente,Independent,4,82048
+Windsor,President,,Baltimore,,Rocky De La Fuente,Independent,2,82048
+Windsor,President,,Barnard,,Rocky De La Fuente,Independent,2,82048
+Caledonia,President,,Barnet,,Rocky De La Fuente,Independent,5,82048
+Washington,President,,Barre City,,Rocky De La Fuente,Independent,21,82048
+Washington,President,,Barre Town,,Rocky De La Fuente,Independent,22,82048
+Orleans,President,,Barton,,Rocky De La Fuente,Independent,4,82048
+Lamoille,President,,Belvidere,,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Bennington,Bennington 2-1,Rocky De La Fuente,Independent,13,82048
+Bennington,President,,Bennington,Bennington 2-2,Rocky De La Fuente,Independent,9,82048
+Rutland,President,,Benson,,Rocky De La Fuente,Independent,3,82048
+Franklin,President,,Berkshire,,Rocky De La Fuente,Independent,8,82048
+Washington,President,,Berlin,,Rocky De La Fuente,Independent,7,82048
+Windsor,President,,Bethel,,Rocky De La Fuente,Independent,2,82048
+Essex,President,,Bloomfield,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Bolton,,Rocky De La Fuente,Independent,2,82048
+Orange,President,,Bradford,,Rocky De La Fuente,Independent,2,82048
+Orange,President,,Braintree,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Brandon,,Rocky De La Fuente,Independent,8,82048
+Windham,President,,Brattleboro,Windham 2-1,Rocky De La Fuente,Independent,5,82048
+Windham,President,,Brattleboro,Windham 2-2,Rocky De La Fuente,Independent,3,82048
+Windham,President,,Brattleboro,Windham 2-3,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Bridgewater,,Rocky De La Fuente,Independent,16,82048
+Addison,President,,Bridport,,Rocky De La Fuente,Independent,3,82048
+Essex,President,,Brighton,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Bristol,,Rocky De La Fuente,Independent,9,82048
+Orange,President,,Brookfield,,Rocky De La Fuente,Independent,10,82048
+Windham,President,,Brookline,,Rocky De La Fuente,Independent,5,82048
+Orleans,President,,Brownington,,Rocky De La Fuente,Independent,1,82048
+Essex,President,,Brunswick,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Burke,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Rocky De La Fuente,Independent,9,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Rocky De La Fuente,Independent,5,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Rocky De La Fuente,Independent,7,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Rocky De La Fuente,Independent,5,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Rocky De La Fuente,Independent,2,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Rocky De La Fuente,Independent,0,82048
+Washington,President,,Cabot,,Rocky De La Fuente,Independent,4,82048
+Washington,President,,Calais,,Rocky De La Fuente,Independent,3,82048
+Lamoille,President,,Cambridge,,Rocky De La Fuente,Independent,6,82048
+Essex,President,,Canaan,,Rocky De La Fuente,Independent,3,82048
+Rutland,President,,Castleton,,Rocky De La Fuente,Independent,6,82048
+Windsor,President,,Cavendish,,Rocky De La Fuente,Independent,5,82048
+Orleans,President,,Charleston,,Rocky De La Fuente,Independent,2,82048
+Chittenden,President,,Charlotte,,Rocky De La Fuente,Independent,6,82048
+Orange,President,,Chelsea,,Rocky De La Fuente,Independent,4,82048
+Windsor,President,,Chester,,Rocky De La Fuente,Independent,3,82048
+Rutland,President,,Chittenden,,Rocky De La Fuente,Independent,2,82048
+Rutland,President,,Clarendon,,Rocky De La Fuente,Independent,2,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Rocky De La Fuente,Independent,9,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Rocky De La Fuente,Independent,13,82048
+Essex,President,,Concord,,Rocky De La Fuente,Independent,2,82048
+Orange,President,,Corinth,,Rocky De La Fuente,Independent,3,82048
+Addison,President,,Cornwall,,Rocky De La Fuente,Independent,3,82048
+Orleans,President,,Coventry,,Rocky De La Fuente,Independent,2,82048
+Orleans,President,,Craftsbury,,Rocky De La Fuente,Independent,3,82048
+Rutland,President,,Danby,,Rocky De La Fuente,Independent,4,82048
+Caledonia,President,,Danville,,Rocky De La Fuente,Independent,4,82048
+Orleans,President,,Derby,,Rocky De La Fuente,Independent,3,82048
+Bennington,President,,Dorset,,Rocky De La Fuente,Independent,4,82048
+Windham,President,,Dover,,Rocky De La Fuente,Independent,3,82048
+Windham,President,,Dummerston,,Rocky De La Fuente,Independent,2,82048
+Washington,President,,Duxbury,,Rocky De La Fuente,Independent,6,82048
+Essex,President,,East Haven,,Rocky De La Fuente,Independent,2,82048
+Washington,President,,East Montpelier,,Rocky De La Fuente,Independent,2,82048
+Lamoille,President,,Eden,,Rocky De La Fuente,Independent,2,82048
+Lamoille,President,,Elmore,,Rocky De La Fuente,Independent,0,82048
+Franklin,President,,Enosburgh,,Rocky De La Fuente,Independent,8,82048
+Chittenden,President,,Essex,Chittenden 8-1,Rocky De La Fuente,Independent,16,82048
+Chittenden,President,,Essex,Chittenden 8-2,Rocky De La Fuente,Independent,14,82048
+Chittenden,President,,Essex,Chittenden 8-3,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Fair Haven,,Rocky De La Fuente,Independent,5,82048
+Franklin,President,,Fairfax,,Rocky De La Fuente,Independent,6,82048
+Franklin,President,,Fairfield,,Rocky De La Fuente,Independent,0,82048
+Orange,President,,Fairlee,,Rocky De La Fuente,Independent,5,82048
+Washington,President,,Fayston,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Ferrisburgh,,Rocky De La Fuente,Independent,3,82048
+Franklin,President,,Fletcher,,Rocky De La Fuente,Independent,3,82048
+Franklin,President,,Franklin,,Rocky De La Fuente,Independent,4,82048
+Franklin,President,,Georgia,,Rocky De La Fuente,Independent,8,82048
+Orleans,President,,Glover,,Rocky De La Fuente,Independent,2,82048
+Addison,President,,Goshen,,Rocky De La Fuente,Independent,0,82048
+Windham,President,,Grafton,,Rocky De La Fuente,Independent,1,82048
+Essex,President,,Granby,,Rocky De La Fuente,Independent,0,82048
+Grand Isle,President,,Grand Isle,,Rocky De La Fuente,Independent,6,82048
+Addison,President,,Granville,,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Greensboro,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Groton,,Rocky De La Fuente,Independent,4,82048
+Essex,President,,Guildhall,,Rocky De La Fuente,Independent,0,82048
+Windham,President,,Guilford,,Rocky De La Fuente,Independent,1,82048
+Windham,President,,Halifax,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Hancock,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Hardwick,,Rocky De La Fuente,Independent,5,82048
+Windsor,President,,Hartford,Windsor 4-1,Rocky De La Fuente,Independent,2,82048
+Windsor,President,,Hartford,Windsor 4-2,Rocky De La Fuente,Independent,20,82048
+Windsor,President,,Hartland,,Rocky De La Fuente,Independent,3,82048
+Franklin,President,,Highgate,,Rocky De La Fuente,Independent,7,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Rocky De La Fuente,Independent,0,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Holland,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Hubbardton,,Rocky De La Fuente,Independent,3,82048
+Chittenden,President,,Huntington,,Rocky De La Fuente,Independent,10,82048
+Lamoille,President,,Hyde Park,,Rocky De La Fuente,Independent,5,82048
+Rutland,President,,Ira,,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Irasburg,,Rocky De La Fuente,Independent,0,82048
+Grand Isle,President,,Isle La Motte,,Rocky De La Fuente,Independent,0,82048
+Windham,President,,Jamaica,,Rocky De La Fuente,Independent,2,82048
+Orleans,President,,Jay,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Jericho,,Rocky De La Fuente,Independent,9,82048
+Lamoille,President,,Johnson,,Rocky De La Fuente,Independent,2,82048
+Rutland,President,,Killington,,Rocky De La Fuente,Independent,2,82048
+Caledonia,President,,Kirby,,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Landgrove,,Rocky De La Fuente,Independent,0,82048
+Addison,President,,Leicester,,Rocky De La Fuente,Independent,3,82048
+Essex,President,,Lemington,,Rocky De La Fuente,Independent,0,82048
+Addison,President,,Lincoln,,Rocky De La Fuente,Independent,3,82048
+Windham,President,,Londonderry,,Rocky De La Fuente,Independent,3,82048
+Orleans,President,,Lowell,,Rocky De La Fuente,Independent,3,82048
+Windsor,President,,Ludlow,,Rocky De La Fuente,Independent,7,82048
+Essex,President,,Lunenburg,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Lyndon,,Rocky De La Fuente,Independent,8,82048
+Essex,President,,Maidstone,,Rocky De La Fuente,Independent,1,82048
+Bennington,President,,Manchester,,Rocky De La Fuente,Independent,10,82048
+Windham,President,,Marlboro,,Rocky De La Fuente,Independent,1,82048
+Washington,President,,Marshfield,,Rocky De La Fuente,Independent,4,82048
+Rutland,President,,Mendon,,Rocky De La Fuente,Independent,3,82048
+Addison,President,,Middlebury,,Rocky De La Fuente,Independent,11,82048
+Washington,President,,Middlesex,,Rocky De La Fuente,Independent,5,82048
+Rutland,President,,Middletown Springs,,Rocky De La Fuente,Independent,7,82048
+Chittenden,President,,Milton,Chittenden 10,Rocky De La Fuente,Independent,17,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Rocky De La Fuente,Independent,2,82048
+Addison,President,,Monkton,,Rocky De La Fuente,Independent,2,82048
+Franklin,President,,Montgomery,,Rocky De La Fuente,Independent,3,82048
+Washington,President,,Montpelier,,Rocky De La Fuente,Independent,7,82048
+Washington,President,,Moretown,,Rocky De La Fuente,Independent,3,82048
+Orleans,President,,Morgan,,Rocky De La Fuente,Independent,1,82048
+Lamoille,President,,Morristown,,Rocky De La Fuente,Independent,9,82048
+Rutland,President,,Mount Holly,,Rocky De La Fuente,Independent,4,82048
+Rutland,President,,Mount Tabor,,Rocky De La Fuente,Independent,0,82048
+Addison,President,,New Haven,,Rocky De La Fuente,Independent,5,82048
+Caledonia,President,,Newark,,Rocky De La Fuente,Independent,0,82048
+Orange,President,,Newbury,,Rocky De La Fuente,Independent,4,82048
+Windham,President,,Newfane,,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Newport City,,Rocky De La Fuente,Independent,4,82048
+Orleans,President,,Newport Town,,Rocky De La Fuente,Independent,3,82048
+Grand Isle,President,,North Hero,,Rocky De La Fuente,Independent,0,82048
+Washington,President,,Northfield,,Rocky De La Fuente,Independent,10,82048
+Essex,President,,Norton,,Rocky De La Fuente,Independent,0,82048
+Windsor,President,,Norwich,,Rocky De La Fuente,Independent,1,82048
+Orange,President,,Orange,,Rocky De La Fuente,Independent,3,82048
+Addison,President,,Orwell,,Rocky De La Fuente,Independent,5,82048
+Addison,President,,Panton,,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,Pawlet,,Rocky De La Fuente,Independent,3,82048
+Caledonia,President,,Peacham,,Rocky De La Fuente,Independent,3,82048
+Bennington,President,,Peru,,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,Pittsfield,,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,Pittsford,,Rocky De La Fuente,Independent,2,82048
+Washington,President,,Plainfield,,Rocky De La Fuente,Independent,3,82048
+Windsor,President,,Plymouth,,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Pomfret,,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,Poultney,,Rocky De La Fuente,Independent,6,82048
+Bennington,President,,Pownal,,Rocky De La Fuente,Independent,8,82048
+Rutland,President,,Proctor,,Rocky De La Fuente,Independent,8,82048
+Windham,President,,Putney,,Rocky De La Fuente,Independent,0,82048
+Orange,President,,Randolph,,Rocky De La Fuente,Independent,11,82048
+Windsor,President,,Reading,,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Readsboro,,Rocky De La Fuente,Independent,1,82048
+Franklin,President,,Richford,,Rocky De La Fuente,Independent,3,82048
+Chittenden,President,,Richmond,,Rocky De La Fuente,Independent,9,82048
+Addison,President,,Ripton,,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Rochester,,Rocky De La Fuente,Independent,1,82048
+Windham,President,,Rockingham,,Rocky De La Fuente,Independent,9,82048
+Washington,President,,Roxbury,,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Royalton,,Rocky De La Fuente,Independent,4,82048
+Bennington,President,,Rupert,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Rutland City,Rutland 5-1,Rocky De La Fuente,Independent,6,82048
+Rutland,President,,Rutland City,Rutland 5-2,Rocky De La Fuente,Independent,8,82048
+Rutland,President,,Rutland City,Rutland 5-3,Rocky De La Fuente,Independent,3,82048
+Rutland,President,,Rutland City,Rutland 5-4,Rocky De La Fuente,Independent,4,82048
+Rutland,President,,Rutland Town,,Rocky De La Fuente,Independent,8,82048
+Caledonia,President,,Ryegate,,Rocky De La Fuente,Independent,0,82048
+Addison,President,,Salisbury,,Rocky De La Fuente,Independent,3,82048
+Bennington,President,,Sandgate,,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Searsburg,,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Shaftsbury,,Rocky De La Fuente,Independent,7,82048
+Windsor,President,,Sharon,,Rocky De La Fuente,Independent,3,82048
+Caledonia,President,,Sheffield,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Rocky De La Fuente,Independent,4,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Rocky De La Fuente,Independent,4,82048
+Franklin,President,,Sheldon,,Rocky De La Fuente,Independent,2,82048
+Addison,President,,Shoreham,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Shrewsbury,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Rocky De La Fuente,Independent,3,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Rocky De La Fuente,Independent,4,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Rocky De La Fuente,Independent,5,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Rocky De La Fuente,Independent,7,82048
+Grand Isle,President,,South Hero,,Rocky De La Fuente,Independent,3,82048
+Windsor,President,,Springfield,Windsor 3-1,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Springfield,Windsor 3-2,Rocky De La Fuente,Independent,17,82048
+Franklin,President,,Saint Albans City,,Rocky De La Fuente,Independent,12,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Rocky De La Fuente,Independent,4,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Rocky De La Fuente,Independent,10,82048
+Chittenden,President,,Saint George,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Saint Johnsbury,,Rocky De La Fuente,Independent,16,82048
+Bennington,President,,Stamford,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Stannard,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Starksboro,,Rocky De La Fuente,Independent,3,82048
+Windsor,President,,Stockbridge,,Rocky De La Fuente,Independent,6,82048
+Lamoille,President,,Stowe,,Rocky De La Fuente,Independent,3,82048
+Orange,President,,Strafford,,Rocky De La Fuente,Independent,1,82048
+Windham,President,,Stratton,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,Sudbury,,Rocky De La Fuente,Independent,2,82048
+Bennington,President,,Sunderland,Bennington 3,Rocky De La Fuente,Independent,0,82048
+Bennington,President,,Sunderland,Bennington 4,Rocky De La Fuente,Independent,3,82048
+Caledonia,President,,Sutton,,Rocky De La Fuente,Independent,3,82048
+Franklin,President,,Swanton,,Rocky De La Fuente,Independent,6,82048
+Orange,President,,Thetford,,Rocky De La Fuente,Independent,2,82048
+Rutland,President,,Tinmouth,Rutland 2,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Rocky De La Fuente,Independent,0,82048
+Orange,President,,Topsham,,Rocky De La Fuente,Independent,7,82048
+Windham,President,,Townshend,,Rocky De La Fuente,Independent,3,82048
+Orleans,President,,Troy,Orleans 2,Rocky De La Fuente,Independent,1,82048
+Orleans,President,,Troy,Orleans-Lamoille,Rocky De La Fuente,Independent,3,82048
+Orange,President,,Tunbridge,,Rocky De La Fuente,Independent,2,82048
+Chittenden,President,,Underhill,,Rocky De La Fuente,Independent,2,82048
+Addison,President,,Vergennes,,Rocky De La Fuente,Independent,5,82048
+Windham,President,,Vernon,,Rocky De La Fuente,Independent,3,82048
+Orange,President,,Vershire,,Rocky De La Fuente,Independent,2,82048
+Essex,President,,Victory,,Rocky De La Fuente,Independent,0,82048
+Washington,President,,Waitsfield,,Rocky De La Fuente,Independent,6,82048
+Caledonia,President,,Walden,,Rocky De La Fuente,Independent,3,82048
+Rutland,President,,Wallingford,,Rocky De La Fuente,Independent,4,82048
+Addison,President,,Waltham,,Rocky De La Fuente,Independent,0,82048
+Windham,President,,Wardsboro,,Rocky De La Fuente,Independent,1,82048
+Washington,President,,Warren,,Rocky De La Fuente,Independent,4,82048
+Orange,President,,Washington,,Rocky De La Fuente,Independent,4,82048
+Washington,President,,Waterbury,,Rocky De La Fuente,Independent,16,82048
+Caledonia,President,,Waterford,,Rocky De La Fuente,Independent,1,82048
+Lamoille,President,,Waterville,,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Weathersfield,,Rocky De La Fuente,Independent,8,82048
+Rutland,President,,Wells,,Rocky De La Fuente,Independent,2,82048
+Orange,President,,West Fairlee,,Rocky De La Fuente,Independent,0,82048
+Rutland,President,,West Haven,,Rocky De La Fuente,Independent,1,82048
+Rutland,President,,West Rutland,,Rocky De La Fuente,Independent,4,82048
+Windsor,President,,West Windsor,,Rocky De La Fuente,Independent,2,82048
+Orleans,President,,Westfield,,Rocky De La Fuente,Independent,1,82048
+Chittenden,President,,Westford,,Rocky De La Fuente,Independent,5,82048
+Windham,President,,Westminster,Windham 3,Rocky De La Fuente,Independent,0,82048
+Windham,President,,Westminster,Windham 4,Rocky De La Fuente,Independent,5,82048
+Orleans,President,,Westmore,,Rocky De La Fuente,Independent,1,82048
+Windsor,President,,Weston,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Weybridge,,Rocky De La Fuente,Independent,1,82048
+Caledonia,President,,Wheelock,,Rocky De La Fuente,Independent,1,82048
+Addison,President,,Whiting,,Rocky De La Fuente,Independent,2,82048
+Windham,President,,Whitingham,Windham 6,Rocky De La Fuente,Independent,4,82048
+Windham,President,,Whitingham,Windham-Bennington,Rocky De La Fuente,Independent,0,82048
+Orange,President,,Williamstown,,Rocky De La Fuente,Independent,10,82048
+Chittenden,President,,Williston,,Rocky De La Fuente,Independent,15,82048
+Windham,President,,Wilmington,,Rocky De La Fuente,Independent,2,82048
+Windham,President,,Windham,,Rocky De La Fuente,Independent,3,82048
+Windsor,President,,Windsor,,Rocky De La Fuente,Independent,3,82048
+Bennington,President,,Winhall,,Rocky De La Fuente,Independent,2,82048
+Chittenden,President,,Winooski,,Rocky De La Fuente,Independent,14,82048
+Lamoille,President,,Wolcott,,Rocky De La Fuente,Independent,3,82048
+Washington,President,,Woodbury,,Rocky De La Fuente,Independent,3,82048
+Bennington,President,,Woodford,,Rocky De La Fuente,Independent,0,82048
+Windsor,President,,Woodstock,,Rocky De La Fuente,Independent,5,82048
+Washington,President,,Worcester,,Rocky De La Fuente,Independent,3,82048
+Addison,President,,Addison,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Albany,,Gloria Lariva,Liberty Union,3,82048
+Grand Isle,President,,Alburgh,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Andover,,Gloria Lariva,Liberty Union,1,82048
+Bennington,President,,Arlington,,Gloria Lariva,Liberty Union,3,82048
+Windham,President,,Athens,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Bakersfield,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Baltimore,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Barnard,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Barnet,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Barre City,,Gloria Lariva,Liberty Union,2,82048
+Washington,President,,Barre Town,,Gloria Lariva,Liberty Union,6,82048
+Orleans,President,,Barton,,Gloria Lariva,Liberty Union,1,82048
+Lamoille,President,,Belvidere,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Bennington,Bennington 2-1,Gloria Lariva,Liberty Union,3,82048
+Bennington,President,,Bennington,Bennington 2-2,Gloria Lariva,Liberty Union,5,82048
+Rutland,President,,Benson,,Gloria Lariva,Liberty Union,2,82048
+Franklin,President,,Berkshire,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Berlin,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Bethel,,Gloria Lariva,Liberty Union,0,82048
+Essex,President,,Bloomfield,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Bolton,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Bradford,,Gloria Lariva,Liberty Union,2,82048
+Orange,President,,Braintree,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Brandon,,Gloria Lariva,Liberty Union,2,82048
+Windham,President,,Brattleboro,Windham 2-1,Gloria Lariva,Liberty Union,1,82048
+Windham,President,,Brattleboro,Windham 2-2,Gloria Lariva,Liberty Union,4,82048
+Windham,President,,Brattleboro,Windham 2-3,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Bridgewater,,Gloria Lariva,Liberty Union,2,82048
+Addison,President,,Bridport,,Gloria Lariva,Liberty Union,1,82048
+Essex,President,,Brighton,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Bristol,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Brookfield,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Brookline,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Brownington,,Gloria Lariva,Liberty Union,0,82048
+Essex,President,,Brunswick,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Burke,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Burlington,Chittenden 6-1,Gloria Lariva,Liberty Union,4,82048
+Chittenden,President,,Burlington,Chittenden 6-2,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Burlington,Chittenden 6-3,Gloria Lariva,Liberty Union,4,82048
+Chittenden,President,,Burlington,Chittenden 6-4,Gloria Lariva,Liberty Union,2,82048
+Chittenden,President,,Burlington,Chittenden 6-5,Gloria Lariva,Liberty Union,5,82048
+Chittenden,President,,Burlington,Chittenden 6-6,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Burlington,Chittenden 6-7,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Cabot,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Calais,,Gloria Lariva,Liberty Union,1,82048
+Lamoille,President,,Cambridge,,Gloria Lariva,Liberty Union,3,82048
+Essex,President,,Canaan,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Castleton,,Gloria Lariva,Liberty Union,3,82048
+Windsor,President,,Cavendish,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Charleston,,Gloria Lariva,Liberty Union,7,82048
+Chittenden,President,,Charlotte,,Gloria Lariva,Liberty Union,2,82048
+Orange,President,,Chelsea,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Chester,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Chittenden,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Clarendon,,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Colchester,Chittenden 9-1,Gloria Lariva,Liberty Union,8,82048
+Chittenden,President,,Colchester,Chittenden 9-2,Gloria Lariva,Liberty Union,1,82048
+Essex,President,,Concord,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Corinth,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Cornwall,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Coventry,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Craftsbury,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Danby,,Gloria Lariva,Liberty Union,5,82048
+Caledonia,President,,Danville,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Derby,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Dorset,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Dover,,Gloria Lariva,Liberty Union,3,82048
+Windham,President,,Dummerston,,Gloria Lariva,Liberty Union,4,82048
+Washington,President,,Duxbury,,Gloria Lariva,Liberty Union,2,82048
+Essex,President,,East Haven,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,East Montpelier,,Gloria Lariva,Liberty Union,1,82048
+Lamoille,President,,Eden,,Gloria Lariva,Liberty Union,1,82048
+Lamoille,President,,Elmore,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Enosburgh,,Gloria Lariva,Liberty Union,6,82048
+Chittenden,President,,Essex,Chittenden 8-1,Gloria Lariva,Liberty Union,6,82048
+Chittenden,President,,Essex,Chittenden 8-2,Gloria Lariva,Liberty Union,3,82048
+Chittenden,President,,Essex,Chittenden 8-3,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Fair Haven,,Gloria Lariva,Liberty Union,1,82048
+Franklin,President,,Fairfax,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Fairfield,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Fairlee,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Fayston,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Ferrisburgh,,Gloria Lariva,Liberty Union,2,82048
+Franklin,President,,Fletcher,,Gloria Lariva,Liberty Union,1,82048
+Franklin,President,,Franklin,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Georgia,,Gloria Lariva,Liberty Union,3,82048
+Orleans,President,,Glover,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Goshen,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Grafton,,Gloria Lariva,Liberty Union,0,82048
+Essex,President,,Granby,,Gloria Lariva,Liberty Union,0,82048
+Grand Isle,President,,Grand Isle,,Gloria Lariva,Liberty Union,2,82048
+Addison,President,,Granville,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Greensboro,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Groton,,Gloria Lariva,Liberty Union,1,82048
+Essex,President,,Guildhall,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Guilford,,Gloria Lariva,Liberty Union,2,82048
+Windham,President,,Halifax,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Hancock,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Hardwick,,Gloria Lariva,Liberty Union,6,82048
+Windsor,President,,Hartford,Windsor 4-1,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Hartford,Windsor 4-2,Gloria Lariva,Liberty Union,6,82048
+Windsor,President,,Hartland,,Gloria Lariva,Liberty Union,1,82048
+Franklin,President,,Highgate,,Gloria Lariva,Liberty Union,3,82048
+Chittenden,President,,Hinesburg,Chittenden 4-1,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Hinesburg,Chittenden 4-2,Gloria Lariva,Liberty Union,2,82048
+Orleans,President,,Holland,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Hubbardton,,Gloria Lariva,Liberty Union,2,82048
+Chittenden,President,,Huntington,,Gloria Lariva,Liberty Union,0,82048
+Lamoille,President,,Hyde Park,,Gloria Lariva,Liberty Union,2,82048
+Rutland,President,,Ira,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Irasburg,,Gloria Lariva,Liberty Union,0,82048
+Grand Isle,President,,Isle La Motte,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Jamaica,,Gloria Lariva,Liberty Union,3,82048
+Orleans,President,,Jay,,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Jericho,,Gloria Lariva,Liberty Union,3,82048
+Lamoille,President,,Johnson,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Killington,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Kirby,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Landgrove,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Leicester,,Gloria Lariva,Liberty Union,0,82048
+Essex,President,,Lemington,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Lincoln,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Londonderry,,Gloria Lariva,Liberty Union,2,82048
+Orleans,President,,Lowell,,Gloria Lariva,Liberty Union,2,82048
+Windsor,President,,Ludlow,,Gloria Lariva,Liberty Union,2,82048
+Essex,President,,Lunenburg,,Gloria Lariva,Liberty Union,2,82048
+Caledonia,President,,Lyndon,,Gloria Lariva,Liberty Union,3,82048
+Essex,President,,Maidstone,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Manchester,,Gloria Lariva,Liberty Union,4,82048
+Windham,President,,Marlboro,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Marshfield,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Mendon,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Middlebury,,Gloria Lariva,Liberty Union,2,82048
+Washington,President,,Middlesex,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Middletown Springs,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Milton,Chittenden 10,Gloria Lariva,Liberty Union,4,82048
+Chittenden,President,,Milton,Grand Isle-Chittenden,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Monkton,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Montgomery,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Montpelier,,Gloria Lariva,Liberty Union,4,82048
+Washington,President,,Moretown,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Morgan,,Gloria Lariva,Liberty Union,0,82048
+Lamoille,President,,Morristown,,Gloria Lariva,Liberty Union,7,82048
+Rutland,President,,Mount Holly,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Mount Tabor,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,New Haven,,Gloria Lariva,Liberty Union,2,82048
+Caledonia,President,,Newark,,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Newbury,,Gloria Lariva,Liberty Union,2,82048
+Windham,President,,Newfane,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Newport City,,Gloria Lariva,Liberty Union,1,82048
+Orleans,President,,Newport Town,,Gloria Lariva,Liberty Union,3,82048
+Grand Isle,President,,North Hero,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Northfield,,Gloria Lariva,Liberty Union,2,82048
+Essex,President,,Norton,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Norwich,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Orange,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Orwell,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Panton,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Pawlet,,Gloria Lariva,Liberty Union,1,82048
+Caledonia,President,,Peacham,,Gloria Lariva,Liberty Union,1,82048
+Bennington,President,,Peru,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Pittsfield,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Pittsford,,Gloria Lariva,Liberty Union,3,82048
+Washington,President,,Plainfield,,Gloria Lariva,Liberty Union,2,82048
+Windsor,President,,Plymouth,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Pomfret,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Poultney,,Gloria Lariva,Liberty Union,4,82048
+Bennington,President,,Pownal,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Proctor,,Gloria Lariva,Liberty Union,1,82048
+Windham,President,,Putney,,Gloria Lariva,Liberty Union,1,82048
+Orange,President,,Randolph,,Gloria Lariva,Liberty Union,2,82048
+Windsor,President,,Reading,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Readsboro,,Gloria Lariva,Liberty Union,1,82048
+Franklin,President,,Richford,,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Richmond,,Gloria Lariva,Liberty Union,5,82048
+Addison,President,,Ripton,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Rochester,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Rockingham,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Roxbury,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Royalton,,Gloria Lariva,Liberty Union,3,82048
+Bennington,President,,Rupert,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Rutland City,Rutland 5-1,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Rutland City,Rutland 5-2,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Rutland City,Rutland 5-3,Gloria Lariva,Liberty Union,2,82048
+Rutland,President,,Rutland City,Rutland 5-4,Gloria Lariva,Liberty Union,3,82048
+Rutland,President,,Rutland Town,,Gloria Lariva,Liberty Union,1,82048
+Caledonia,President,,Ryegate,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Salisbury,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Sandgate,,Gloria Lariva,Liberty Union,1,82048
+Bennington,President,,Searsburg,,Gloria Lariva,Liberty Union,1,82048
+Bennington,President,,Shaftsbury,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Sharon,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Sheffield,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Shelburne,Chittenden 5-1,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Shelburne,Chittenden 5-2,Gloria Lariva,Liberty Union,1,82048
+Franklin,President,,Sheldon,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Shoreham,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Shrewsbury,,Gloria Lariva,Liberty Union,2,82048
+Chittenden,President,,South Burlington,Chittenden 7-1,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,South Burlington,Chittenden 7-2,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,South Burlington,Chittenden 7-3,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,South Burlington,Chittenden 7-4,Gloria Lariva,Liberty Union,1,82048
+Grand Isle,President,,South Hero,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Springfield,Windsor 3-1,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Springfield,Windsor 3-2,Gloria Lariva,Liberty Union,2,82048
+Franklin,President,,Saint Albans City,,Gloria Lariva,Liberty Union,3,82048
+Franklin,President,,Saint Albans Town,Franklin 3-1,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Saint Albans Town,Franklin 3-2,Gloria Lariva,Liberty Union,3,82048
+Chittenden,President,,Saint George,,Gloria Lariva,Liberty Union,1,82048
+Caledonia,President,,Saint Johnsbury,,Gloria Lariva,Liberty Union,4,82048
+Bennington,President,,Stamford,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Stannard,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Starksboro,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Stockbridge,,Gloria Lariva,Liberty Union,0,82048
+Lamoille,President,,Stowe,,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Strafford,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Stratton,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Sudbury,,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Sunderland,Bennington 3,Gloria Lariva,Liberty Union,0,82048
+Bennington,President,,Sunderland,Bennington 4,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Sutton,,Gloria Lariva,Liberty Union,0,82048
+Franklin,President,,Swanton,,Gloria Lariva,Liberty Union,2,82048
+Orange,President,,Thetford,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Tinmouth,Rutland 2,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,Tinmouth,Rutland-Bennington,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Topsham,,Gloria Lariva,Liberty Union,1,82048
+Windham,President,,Townshend,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Troy,Orleans 2,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Troy,Orleans-Lamoille,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Tunbridge,,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Underhill,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Vergennes,,Gloria Lariva,Liberty Union,1,82048
+Windham,President,,Vernon,,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Vershire,,Gloria Lariva,Liberty Union,0,82048
+Essex,President,,Victory,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Waitsfield,,Gloria Lariva,Liberty Union,0,82048
+Caledonia,President,,Walden,,Gloria Lariva,Liberty Union,2,82048
+Rutland,President,,Wallingford,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Waltham,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Wardsboro,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Warren,,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Washington,,Gloria Lariva,Liberty Union,0,82048
+Washington,President,,Waterbury,,Gloria Lariva,Liberty Union,1,82048
+Caledonia,President,,Waterford,,Gloria Lariva,Liberty Union,0,82048
+Lamoille,President,,Waterville,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Weathersfield,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,Wells,,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,West Fairlee,,Gloria Lariva,Liberty Union,1,82048
+Rutland,President,,West Haven,,Gloria Lariva,Liberty Union,0,82048
+Rutland,President,,West Rutland,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,West Windsor,,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Westfield,,Gloria Lariva,Liberty Union,0,82048
+Chittenden,President,,Westford,,Gloria Lariva,Liberty Union,5,82048
+Windham,President,,Westminster,Windham 3,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Westminster,Windham 4,Gloria Lariva,Liberty Union,0,82048
+Orleans,President,,Westmore,,Gloria Lariva,Liberty Union,0,82048
+Windsor,President,,Weston,,Gloria Lariva,Liberty Union,0,82048
+Addison,President,,Weybridge,,Gloria Lariva,Liberty Union,2,82048
+Caledonia,President,,Wheelock,,Gloria Lariva,Liberty Union,1,82048
+Addison,President,,Whiting,,Gloria Lariva,Liberty Union,0,82048
+Windham,President,,Whitingham,Windham 6,Gloria Lariva,Liberty Union,1,82048
+Windham,President,,Whitingham,Windham-Bennington,Gloria Lariva,Liberty Union,0,82048
+Orange,President,,Williamstown,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Williston,,Gloria Lariva,Liberty Union,2,82048
+Windham,President,,Wilmington,,Gloria Lariva,Liberty Union,2,82048
+Windham,President,,Windham,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Windsor,,Gloria Lariva,Liberty Union,2,82048
+Bennington,President,,Winhall,,Gloria Lariva,Liberty Union,1,82048
+Chittenden,President,,Winooski,,Gloria Lariva,Liberty Union,7,82048
+Lamoille,President,,Wolcott,,Gloria Lariva,Liberty Union,1,82048
+Washington,President,,Woodbury,,Gloria Lariva,Liberty Union,2,82048
+Bennington,President,,Woodford,,Gloria Lariva,Liberty Union,1,82048
+Windsor,President,,Woodstock,,Gloria Lariva,Liberty Union,2,82048
+Washington,President,,Worcester,,Gloria Lariva,Liberty Union,1,82048
 Addison,President,,Addison,,Write-ins,,12,82048
 Orleans,President,,Albany,,Write-ins,,1,82048
 Grand Isle,President,,Alburgh,,Write-ins,,4,82048


### PR DESCRIPTION
Our convention is to only include the presidential candidate's name in the President rows.

This fixes #2.